### PR TITLE
Fix update_frequency bug in budget configuration

### DIFF
--- a/backend/budget_configurable_orchestrator.py
+++ b/backend/budget_configurable_orchestrator.py
@@ -154,7 +154,7 @@ class BudgetConfigurableOrchestrator:
                 intelligence_level=intelligence_level,
                 enabled_features=enabled_features,
                 api_call_limits=api_limits,
-                update_frequency="daily" if monthly_budget >= 200 else "daily"
+                update_frequency="daily" if monthly_budget >= 200 else "weekly"
             )
             
             # Store in database


### PR DESCRIPTION
Fix `update_frequency` logic to ensure it varies based on monthly budget.

Previously, the `update_frequency` was always set to "daily" regardless of the `monthly_budget` value, making the conditional expression redundant. This change ensures that budgets >= $200 receive "daily" updates, while budgets < $200 receive "weekly" updates, making the budget-based logic functional.