### PR TITLE
Resolve dependency conflicts in requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -74,7 +74,7 @@ numpy==1.26.2
 pytz==2023.3
 
 # তমিল - Optional: URL parsing
-yarl==1.9.4
+yarl==1.17.0
 
 # তমিল - Optional: JSON handling
 orjson==3.9.10


### PR DESCRIPTION
Update yarl version to resolve a dependency conflict with aiohttp.

The previous `yarl==1.9.4` was incompatible with `aiohttp==3.12.13`, which requires `yarl>=1.17.0`. Updating `yarl` to `1.17.0` resolves this conflict.