### PR TITLE
Add JWT debug line to diagnose authentication issue

### DIFF
--- a/backend/deps.py
+++ b/backend/deps.py
@@ -18,6 +18,7 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
     """
     try:
         token = credentials.credentials
+        print(f"DEBUG: JWT_SECRET_KEY={JWT_SECRET_KEY}, Token={token[:50]}...")
         payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
         user_id: str = payload.get("sub")
         if user_id is None:


### PR DESCRIPTION
- Added debug output to show JWT_SECRET_KEY and token in deps.py
- This will help identify why admin endpoints return 403 'Not authenticated'
- Minimal surgical fix - only one line added for debugging