### PR TITLE
SURGICAL FIX: JWT user_id consistency + database method fix

### DIFF
--- a/backend/routers/credits.py
+++ b/backend/routers/credits.py
@@ -17,7 +17,8 @@ def get_user_id_from_token(request: Request) -> str:
     token = auth.split(" ")[1]
     try:
         payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        return payload["user_id"]
+        # SURGICAL FIX: Use 'sub' field to match livechat and deps.py
+        return payload.get("sub") or payload.get("user_id")
     except Exception:
         raise HTTPException(status_code=401, detail="தவறான அங்கீகாரம் - தயவுசெய்து மீண்டும் உள்நுழையவும்")
 

--- a/backend/routers/livechat.py
+++ b/backend/routers/livechat.py
@@ -115,9 +115,10 @@ async def get_livechat_pricing_from_universal_engine(session_type: str, duration
 async def validate_user_credits(user_id: int, required_credits: int, db) -> bool:
     """Validate user has sufficient credits"""
     try:
-        user_credits = await db.fetch_one("""
-            SELECT credits FROM users WHERE id = ?
-        """, (user_id,))
+        # SURGICAL FIX: Use fetchrow instead of fetch_one for PostgreSQL asyncpg
+        user_credits = await db.fetchrow("""
+            SELECT credits FROM users WHERE id = $1
+        """, user_id)
         
         if not user_credits:
             return False

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -32,7 +32,8 @@ def get_user_id_from_token(request: Request) -> str:
     token = auth.split(" ")[1]
     try:
         payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        return payload["user_id"]
+        # SURGICAL FIX: Use 'sub' field to match livechat and deps.py
+        return payload.get("sub") or payload.get("user_id")
     except Exception:
         raise HTTPException(status_code=401, detail="Invalid token")
 

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -19,7 +19,8 @@ def get_user_id_from_token(request: Request) -> str:
             return None
         token = auth.split(" ")[1]
         payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
-        return payload["user_id"]
+        # SURGICAL FIX: Use 'sub' field to match livechat and deps.py
+        return payload.get("sub") or payload.get("user_id")
     except Exception:
         return None
 


### PR DESCRIPTION
- Fixed livechat credit validation: fetch_one -> fetchrow (PostgreSQL asyncpg)
- Fixed JWT user_id extraction consistency across all routers
- All routers now use 'sub' field from JWT payload consistently
- This should resolve 402 Payment Required error and user profile credit mismatch