### PR TITLE
SURGICAL FIX: AI Marketing Director frontend response field

### DIFF
--- a/frontend/src/components/admin/MarketingAgentChat.jsx
+++ b/frontend/src/components/admin/MarketingAgentChat.jsx
@@ -44,7 +44,7 @@ const MarketingAgentChat = () => {
       if (response.data.success) {
         setMessages(prev => [...prev, { 
           sender: 'agent', 
-          text: response.data.data.reply 
+          text: response.data.data.message  // SURGICAL FIX: Use 'message' field instead of 'reply'
         }]);
       } else {
         setMessages(prev => [...prev, { 


### PR DESCRIPTION
- Fixed frontend to use 'message' field instead of 'reply'
- Backend returns data.message but frontend was looking for data.reply
- This resolves the 'Could not get response from agent' error
- AI Marketing Director should now display responses properly