### PR TITLE
Initialize JyotiFlow database and backend

### DIFF
--- a/DATABASE_STARTUP_FIXES.md
+++ b/DATABASE_STARTUP_FIXES.md
@@ -1,0 +1,107 @@
+# Database Startup Issues - Fixed
+
+## Issues Identified in Logs
+
+Based on the startup logs from JyotiFlow.ai backend, two critical database-related issues were identified and fixed:
+
+### 1. Database Schema Fix Function Signature Error
+
+**Error Message:**
+```
+⚠️ Database schema fix failed: fix_database_schema() takes 0 positional arguments but 1 was given
+```
+
+**Root Cause:**
+In `backend/main.py` line 147, the code was calling:
+```python
+schema_fix_success = await fix_database_schema(db_pool)
+```
+
+But the function `fix_database_schema()` in `backend/db_schema_fix.py` takes no arguments.
+
+**Fix Applied:**
+```python
+# Changed from:
+schema_fix_success = await fix_database_schema(db_pool)
+
+# To:
+schema_fix_success = await fix_database_schema()
+```
+
+### 2. ON CONFLICT Constraint Error
+
+**Error Message:**
+```
+2025-07-11 05:41:34,669 - init_database - ERROR - Error inserting initial data: there is no unique or exclusion constraint matching the ON CONFLICT specification
+```
+
+**Root Cause:**
+The `_insert_initial_data()` method in `backend/init_database.py` was using `ON CONFLICT` clauses that didn't match the actual database constraints. This can happen due to:
+- Tables not having the expected unique constraints
+- Timing issues during table creation
+- Constraint names not matching expectations
+
+**Fix Applied:**
+Replaced all `ON CONFLICT` clauses with explicit existence checks for safer data insertion:
+
+#### Before (Problematic):
+```python
+await conn.execute("""
+    INSERT INTO service_types (name, description, base_credits, duration_minutes, video_enabled)
+    VALUES ($1, $2, $3, $4, $5)
+    ON CONFLICT (name) DO NOTHING
+""", *service)
+```
+
+#### After (Fixed):
+```python
+# Check if service already exists
+existing = await conn.fetchrow(
+    "SELECT id FROM service_types WHERE name = $1", service[0]
+)
+if not existing:
+    await conn.execute("""
+        INSERT INTO service_types (name, description, base_credits, duration_minutes, video_enabled)
+        VALUES ($1, $2, $3, $4, $5)
+    """, *service)
+```
+
+## Tables Fixed
+
+The following tables had their insert operations updated to use explicit existence checks:
+
+1. **service_types** - Default spiritual guidance services
+2. **avatar_templates** - Avatar generation templates  
+3. **service_configuration_cache** - Service configuration data
+4. **platform_settings** - Platform API credentials and settings
+5. **social_content** - Sample social media content
+
+## Benefits of the Fix
+
+1. **More Robust**: Doesn't rely on specific constraint names or timing
+2. **Explicit**: Clear about what's being checked before insertion
+3. **Safer**: Works even if unique constraints aren't properly created
+4. **Debuggable**: Easier to trace what's happening during initialization
+
+## Expected Results
+
+After these fixes, the application should:
+- ✅ Start without the function signature error
+- ✅ Successfully insert initial data without ON CONFLICT errors
+- ✅ Complete database initialization successfully
+- ✅ Proceed with enhanced system initialization
+
+## Files Modified
+
+1. `backend/main.py` - Fixed function call signature
+2. `backend/init_database.py` - Replaced ON CONFLICT with explicit checks
+
+## Testing Recommendation
+
+To verify the fixes work correctly:
+
+1. **Clean restart**: Test with a fresh database to ensure initialization works
+2. **Repeated starts**: Test multiple startups to ensure duplicate insertion is handled correctly
+3. **Partial data**: Test with some initial data already present
+
+The fixes maintain the same functionality while being more robust and less prone to constraint-related errors.

--- a/backend/init_database.py
+++ b/backend/init_database.py
@@ -561,11 +561,15 @@ class JyotiFlowDatabaseInitializer:
             ]
             
             for service in default_services:
-                await conn.execute("""
-                    INSERT INTO service_types (name, description, base_credits, duration_minutes, video_enabled)
-                    VALUES ($1, $2, $3, $4, $5)
-                    ON CONFLICT (name) DO NOTHING
-                """, *service)
+                # Check if service already exists
+                existing = await conn.fetchrow(
+                    "SELECT id FROM service_types WHERE name = $1", service[0]
+                )
+                if not existing:
+                    await conn.execute("""
+                        INSERT INTO service_types (name, description, base_credits, duration_minutes, video_enabled)
+                        VALUES ($1, $2, $3, $4, $5)
+                    """, *service)
             
             # Insert default avatar templates
             avatar_templates = [
@@ -576,11 +580,15 @@ class JyotiFlowDatabaseInitializer:
             ]
             
             for template in avatar_templates:
-                await conn.execute("""
-                    INSERT INTO avatar_templates (template_name, avatar_style, voice_tone, background_style, clothing_style)
-                    VALUES ($1, $2, $3, $4, $5)
-                    ON CONFLICT (template_name) DO NOTHING
-                """, *template)
+                # Check if template already exists
+                existing = await conn.fetchrow(
+                    "SELECT id FROM avatar_templates WHERE template_name = $1", template[0]
+                )
+                if not existing:
+                    await conn.execute("""
+                        INSERT INTO avatar_templates (template_name, avatar_style, voice_tone, background_style, clothing_style)
+                        VALUES ($1, $2, $3, $4, $5)
+                    """, *template)
             
             # Insert default service configurations
             service_configs = [
@@ -615,16 +623,21 @@ class JyotiFlowDatabaseInitializer:
             ]
             
             for config in service_configs:
-                await conn.execute("""
-                    INSERT INTO service_configuration_cache (service_name, configuration, persona_config, knowledge_domains)
-                    VALUES ($1, $2, $3, $4)
-                    ON CONFLICT (service_name) DO NOTHING
-                """, (
-                    config["service_name"],
-                    json.dumps(config["configuration"]),
-                    json.dumps(config["persona_config"]),
-                    config["knowledge_domains"]
-                ))
+                # Check if service configuration already exists
+                existing = await conn.fetchrow(
+                    "SELECT service_name FROM service_configuration_cache WHERE service_name = $1", 
+                    config["service_name"]
+                )
+                if not existing:
+                    await conn.execute("""
+                        INSERT INTO service_configuration_cache (service_name, configuration, persona_config, knowledge_domains)
+                        VALUES ($1, $2, $3, $4)
+                    """, (
+                        config["service_name"],
+                        json.dumps(config["configuration"]),
+                        json.dumps(config["persona_config"]),
+                        config["knowledge_domains"]
+                    ))
             
             # Insert initial platform settings
             platform_settings = [
@@ -649,11 +662,15 @@ class JyotiFlowDatabaseInitializer:
             ]
             
             for setting_key, setting_value in platform_settings:
-                await conn.execute("""
-                    INSERT INTO platform_settings (key, value)
-                    VALUES ($1, $2)
-                    ON CONFLICT (key) DO NOTHING
-                """, (setting_key, json.dumps(setting_value)))
+                # Check if platform setting already exists
+                existing = await conn.fetchrow(
+                    "SELECT id FROM platform_settings WHERE key = $1", setting_key
+                )
+                if not existing:
+                    await conn.execute("""
+                        INSERT INTO platform_settings (key, value)
+                        VALUES ($1, $2)
+                    """, (setting_key, json.dumps(setting_value)))
             
             # Insert sample social media content for testing
             now = datetime.now()
@@ -676,13 +693,17 @@ class JyotiFlowDatabaseInitializer:
             ]
             
             for content in sample_social_content:
-                await conn.execute("""
-                    INSERT INTO social_content 
-                    (content_id, content_type, platform, title, content_text, media_url, hashtags, 
-                     scheduled_at, published_at, status)
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                    ON CONFLICT (content_id) DO NOTHING
-                """, content)
+                # Check if social content already exists
+                existing = await conn.fetchrow(
+                    "SELECT id FROM social_content WHERE content_id = $1", content[0]
+                )
+                if not existing:
+                    await conn.execute("""
+                        INSERT INTO social_content 
+                        (content_id, content_type, platform, title, content_text, media_url, hashtags, 
+                         scheduled_at, published_at, status)
+                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                    """, content)
             
             logger.info("✅ Initial data inserted")
             logger.info("✅ Sample social media content created")

--- a/backend/main.py
+++ b/backend/main.py
@@ -145,7 +145,7 @@ async def lifespan(app: FastAPI):
         # Apply database schema fixes
         try:
             print("🔧 Applying database schema fixes...")
-            schema_fix_success = await fix_database_schema(db_pool)
+            schema_fix_success = await fix_database_schema()
             if schema_fix_success:
                 print("✅ Database schema fixes applied successfully")
             else:


### PR DESCRIPTION
Fix database initialization errors by correcting a function call and making initial data insertion more robust.

The `ON CONFLICT` clauses were failing due to a "no unique or exclusion constraint matching" error, indicating a brittle dependency on specific constraint names or creation timing. Replacing them with explicit `SELECT` checks ensures data is only inserted if it doesn't already exist, making the initialization process more robust and reliable.