### PR TITLE
Restore JavaScript and CSS in index.html

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -27,9 +27,13 @@
     <!-- Spiritual Theme Colors -->
     <meta name="theme-color" content="#DAA520" />
     <meta name="msapplication-TileColor" content="#DAA520" />
+    
+    <!-- Built CSS -->
+    <link rel="stylesheet" href="/assets/index-DqrvHCVv.css">
   </head>
   <body>
     <div id="root"></div>
+    <script type="module" src="/assets/index-DqrvHCVv.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Add missing CSS and JavaScript bundle references to `index.html` to restore application functionality.