### PR TITLE
Remove hardcoded JWT secret values

### DIFF
--- a/backend/deploy_surgical_fixes.py
+++ b/backend/deploy_surgical_fixes.py
@@ -19,7 +19,17 @@ async def verify_jwt_configuration():
     """Verify JWT configuration is consistent across all modules"""
     logger.info("🔍 Verifying JWT configuration...")
     
-    jwt_secret = os.getenv("JWT_SECRET", "1cdc8d78417b8fc61716ccc3d5e169cc")
+    jwt_secret = os.getenv("JWT_SECRET")
+    if not jwt_secret:
+        logger.error("❌ JWT_SECRET environment variable is not set!")
+        raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
+    
+    # Verify secret is not the old hardcoded value
+    if jwt_secret == "1cdc8d78417b8fc61716ccc3d5e169cc":
+        logger.error("❌ JWT_SECRET is using the old hardcoded value! This is a security vulnerability.")
+        raise RuntimeError("JWT_SECRET cannot use the old hardcoded value. Please generate a new secure secret.")
+    
+    logger.info("✅ JWT_SECRET is properly configured")
     
     # Check key files for JWT secret consistency
     files_to_check = [

--- a/backend/deps.py
+++ b/backend/deps.py
@@ -8,8 +8,10 @@ import os
 # Security scheme for JWT tokens
 security_scheme = HTTPBearer()
 
-# JWT configuration - SURGICAL FIX: Use consistent environment variable
-JWT_SECRET_KEY = os.getenv("JWT_SECRET", "1cdc8d78417b8fc61716ccc3d5e169cc")
+# JWT configuration - SECURITY FIX: Remove hardcoded fallback
+JWT_SECRET_KEY = os.getenv("JWT_SECRET")
+if not JWT_SECRET_KEY:
+    raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
 JWT_ALGORITHM = "HS256"
 
 async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security_scheme)) -> Dict[str, Any]:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -6,8 +6,10 @@ import jwt
 import os
 from datetime import datetime, timedelta
 
-# தமிழ் - ரகசியம் (SECRET)
-JWT_SECRET = os.getenv("JWT_SECRET", "jyotiflow_secret")
+# தமிழ் - ரகசியம் (SECRET) - SECURITY FIX: Remove hardcoded fallback
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
 JWT_ALGORITHM = "HS256"
 JWT_EXPIRY_MINUTES = 60 * 24
 

--- a/backend/routers/credits.py
+++ b/backend/routers/credits.py
@@ -6,7 +6,10 @@ from datetime import datetime
 
 router = APIRouter(prefix="/api/credits", tags=["Credits"])
 
-JWT_SECRET = os.getenv("JWT_SECRET", "jyotiflow_secret")
+# SECURITY FIX: Remove hardcoded fallback
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
 JWT_ALGORITHM = "HS256"
 
 def get_user_id_from_token(request: Request) -> str:

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -19,8 +19,10 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "your-openai-api-key")
 
 router = APIRouter(prefix="/api/sessions", tags=["Sessions"])
 
-# SURGICAL FIX: Use consistent JWT secret configuration
-JWT_SECRET = os.getenv("JWT_SECRET", "1cdc8d78417b8fc61716ccc3d5e169cc")
+# SECURITY FIX: Remove hardcoded fallback
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
 JWT_ALGORITHM = "HS256"
 
 logger = logging.getLogger(__name__)

--- a/backend/routers/spiritual.py
+++ b/backend/routers/spiritual.py
@@ -15,8 +15,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/spiritual", tags=["Spiritual"])
 
-# SURGICAL FIX: Use consistent JWT secret configuration
-JWT_SECRET_KEY = os.getenv("JWT_SECRET", "1cdc8d78417b8fc61716ccc3d5e169cc")
+# SECURITY FIX: Remove hardcoded fallback
+JWT_SECRET_KEY = os.getenv("JWT_SECRET")
+if not JWT_SECRET_KEY:
+    raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
 JWT_ALGORITHM = "HS256"
 
 # --- Helper function to extract user email from JWT token (OPTIONAL) ---

--- a/backend/routers/user.py
+++ b/backend/routers/user.py
@@ -8,7 +8,10 @@ from typing import Dict, Any
 
 router = APIRouter(prefix="/api/user", tags=["User"])
 
-JWT_SECRET = os.getenv("JWT_SECRET", "jyotiflow_secret")
+# SECURITY FIX: Remove hardcoded fallback
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    raise RuntimeError("JWT_SECRET environment variable is required for security. Please set it before starting the application.")
 JWT_ALGORITHM = "HS256"
 
 def get_user_id_from_token(request: Request) -> str:


### PR DESCRIPTION
Remove hardcoded JWT secrets and enforce environment variable configuration to fix a critical security vulnerability.

This change eliminates the exposure of fallback JWT secrets, which could be used to forge authentication tokens. The application now explicitly requires the `JWT_SECRET` environment variable to be set, failing to start if it's missing or uses a previously hardcoded value, thereby enhancing security.