### PR TITLE
Fix optional import error in startup

### DIFF
--- a/backend/unified_startup_system.py
+++ b/backend/unified_startup_system.py
@@ -10,6 +10,7 @@ import asyncpg
 import logging
 import traceback
 from datetime import datetime
+from typing import Optional
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Import `Optional` from `typing` to resolve a `NameError` during application startup.

The application failed to start because `Optional` was used as a type hint in `unified_startup_system.py` without being imported, leading to a `NameError`. Adding the import resolves this critical startup issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal imports to improve code clarity. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->