### PR TITLE
🐛 Fix registration success response issue

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -78,6 +78,7 @@ async def register(form: RegisterForm, db=Depends(get_db)):
         
         token = await create_jwt_token(user_id, form.email, "user")
         return {
+            "success": True,
             "access_token": token, 
             "user": {
                 "id": str(user_id), 


### PR DESCRIPTION
- Add missing 'success: true' field to registration response in backend/routers/auth.py
- Frontend expects 'result.success' but backend was not returning success field
- Database was saving data correctly but frontend showed 'Registration failed' error
- Now registration will work end-to-end: save data + show success message + auto-login