### PR TITLE
feat: Save platform settings to database

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -17,6 +17,8 @@ from pydantic import BaseModel, Field
 
 # CORE.MD: All necessary dependencies are explicitly imported.
 from auth.auth_helpers import AuthenticationHelper
+from core.dependencies import get_database_manager
+from database.database_manager import DatabaseManager
 from schemas.response import StandardResponse
 from schemas.social_media import (
     Campaign,
@@ -178,45 +180,63 @@ async def get_campaigns(
 # --- Platform Configuration Endpoints (using placeholder data) ---
 
 @social_marketing_router.get("/platform-config", response_model=StandardResponse)
-async def get_platform_config(admin_user: dict = Depends(AuthenticationHelper.verify_admin_access_strict)):
-    config_data = PlatformConfig(
-        facebook=PlatformStatus(connected=True, username="jyotiflow.ai"),
-        twitter=PlatformStatus(connected=False, username=None),
-        instagram=PlatformStatus(connected=True, username="@jyotiflow.ai"),
-        youtube=PlatformStatus(connected=True, username="JyotiFlowChannel"),
-        linkedin=PlatformStatus(connected=False, username=None),
-        tiktok=PlatformStatus(connected=False, username=None),
-    )
-    return StandardResponse(success=True, data=config_data, message="Platform configuration retrieved successfully.")
+async def get_platform_config(
+    admin_user: dict = Depends(AuthenticationHelper.verify_admin_access_strict),
+    db: DatabaseManager = Depends(get_database_manager)
+):
+    """Retrieve current platform configurations from the database."""
+    try:
+        rows = await db.fetch_all("SELECT key, value FROM platform_settings WHERE key LIKE '%_config'")
+        
+        config_data = {}
+        for row in rows:
+            platform_name = row['key'].replace('_config', '')
+            # The value from DB is a JSON string, so we parse it.
+            config_data[platform_name] = PlatformStatus(**json.loads(row['value']))
+
+        # Ensure all platforms are present in the response, even if not in the DB
+        final_config = PlatformConfig(**config_data)
+        
+        return StandardResponse(success=True, data=final_config, message="Platform configuration retrieved successfully.")
+    except Exception as e:
+        logger.error(f"Failed to retrieve platform configuration from database: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to retrieve platform configuration.")
+
 
 @social_marketing_router.post("/platform-config", response_model=StandardResponse)
 async def save_platform_config(
     config_request: PlatformConfig,
-    admin_user: dict = Depends(AuthenticationHelper.verify_admin_access_strict)
+    admin_user: dict = Depends(AuthenticationHelper.verify_admin_access_strict),
+    db: DatabaseManager = Depends(get_database_manager)
 ):
+    """Save platform configurations to the database."""
     try:
-        logger.info(f"Attempting to save platform config: {config_request.dict()}")
+        logger.info(f"Attempting to save platform config to database: {config_request.dict()}")
         
-        # CORE.MD: Use a structured and safe approach for file-based persistence.
-        # This is a placeholder for a real database implementation.
-        cache_dir = Path("backend/cache")
-        
-        # REFRESH.MD: Proactively check for directory existence and permissions.
-        try:
-            cache_dir.mkdir(parents=True, exist_ok=True)
-        except OSError as e:
-            logger.error(f"Error creating cache directory {cache_dir}: {e}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Failed to create configuration directory due to permission error.")
-
-        # In a production environment, this path should be configurable.
-        config_path = cache_dir / "platform_config_cache.json"
-
-        with open(config_path, "w") as f:
-            json.dump(config_request.dict(), f, indent=2)
+        async with db.get_connection() as conn:
+            # Using a transaction to ensure all or nothing is saved
+            async with conn.transaction():
+                for platform, status in config_request.dict().items():
+                    if isinstance(status, dict): # Ensure we only process platform statuses
+                        key = f"{platform}_config"
+                        # Convert the status dictionary to a JSON string to store in the JSONB column
+                        value = json.dumps(status)
+                        
+                        # Use INSERT ... ON CONFLICT DO UPDATE to handle both new and existing settings
+                        await conn.execute(
+                            """
+                            INSERT INTO platform_settings (key, value)
+                            VALUES ($1, $2)
+                            ON CONFLICT (key) DO UPDATE
+                            SET value = EXCLUDED.value, updated_at = NOW()
+                            """,
+                            key,
+                            value
+                        )
 
         return StandardResponse(success=True, message="Configuration saved successfully.")
     except Exception as e:
-        logger.error(f"Failed to save platform configuration: {e}", exc_info=True)
+        logger.error(f"Failed to save platform configuration to database: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred while saving the configuration: {e}")
 
 

--- a/backend/schemas/social_media.py
+++ b/backend/schemas/social_media.py
@@ -27,6 +27,9 @@ class PlatformStatus(BaseModel):
     last_sync: Optional[datetime] = None
     error_message: Optional[str] = None
 
+    class Config:
+        extra = 'ignore'
+
 
 class PlatformConfig(BaseModel):
     """Social media platform configuration"""

--- a/backend/schemas/social_media.py
+++ b/backend/schemas/social_media.py
@@ -33,12 +33,15 @@ class PlatformStatus(BaseModel):
 
 class PlatformConfig(BaseModel):
     """Social media platform configuration"""
-    facebook: PlatformStatus = PlatformStatus()
-    instagram: PlatformStatus = PlatformStatus()
-    twitter: PlatformStatus = PlatformStatus()
-    youtube: PlatformStatus = PlatformStatus()
-    linkedin: PlatformStatus = PlatformStatus()
-    tiktok: PlatformStatus = PlatformStatus()
+    facebook: PlatformStatus = Field(default_factory=PlatformStatus)
+    instagram: PlatformStatus = Field(default_factory=PlatformStatus)
+    twitter: PlatformStatus = Field(default_factory=PlatformStatus)
+    youtube: PlatformStatus = Field(default_factory=PlatformStatus)
+    linkedin: PlatformStatus = Field(default_factory=PlatformStatus)
+    tiktok: PlatformStatus = Field(default_factory=PlatformStatus)
+
+    class Config:
+        extra = 'ignore'
 
 
 class TestConnectionRequest(BaseModel):


### PR DESCRIPTION
Implements database persistence for social media platform configurations. The 'get_platform_config' and 'save_platform_config' endpoints now use the 'platform_settings' table instead of a temporary cache file. This ensures that settings are not lost on application restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved platform configuration endpoints to use database storage for saving and retrieving settings, replacing previous file-based methods.
  * Enhanced error handling and logging for configuration operations.

* **New Features**
  * Platform configuration now supports seamless updates and retrievals via the database.

* **Style**
  * Updated model validation to ignore unexpected fields in platform status configurations, improving flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->