### PR TITLE
fix: Use relative imports in social media router

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -17,8 +17,7 @@ from pydantic import BaseModel, Field
 
 # CORE.MD: All necessary dependencies are explicitly imported.
 from ..auth.auth_helpers import AuthenticationHelper
-from ..core.dependencies import get_database_manager
-from ..database.database_manager import DatabaseManager
+from ..main import get_database_manager, DatabaseManager
 from ..schemas.response import StandardResponse
 from ..schemas.social_media import (
     Campaign,

--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -16,11 +16,11 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from pydantic import BaseModel, Field
 
 # CORE.MD: All necessary dependencies are explicitly imported.
-from auth.auth_helpers import AuthenticationHelper
-from core.dependencies import get_database_manager
-from database.database_manager import DatabaseManager
-from schemas.response import StandardResponse
-from schemas.social_media import (
+from ..auth.auth_helpers import AuthenticationHelper
+from ..core.dependencies import get_database_manager
+from ..database.database_manager import DatabaseManager
+from ..schemas.response import StandardResponse
+from ..schemas.social_media import (
     Campaign,
     ContentCalendarItem,
     GenerateAllAvatarPreviewsRequest,


### PR DESCRIPTION
This commit corrects all absolute imports in 'social_media_marketing_router.py' to use relative paths (e.g., 'from ..core...'). This resolves the 'ModuleNotFoundError: No module named 'core'' that was causing application startup failure during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated module imports to use relative paths. No changes to features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->