### PR TITLE
fix(router): Remove unused PlatformStatus import

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -30,7 +30,6 @@ from schemas.social_media import (
     MarketingOverview,
     PlatformConfig,
     PlatformConfigUpdate,
-    PlatformStatus,
     TestConnectionRequest,
     PostExecutionRequest,
     PostExecutionResult,


### PR DESCRIPTION
This commit removes the unused import of 'PlatformStatus' from the social media router. This resolves an 'ImportError' that was causing application startup failure during deployment after the recent Pydantic model refactoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal imports to improve code organization. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->