### PR TITLE
fix(api): Correct dependency for file upload

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -339,7 +339,10 @@ async def get_swamiji_avatar_config(admin_user: dict = Depends(AuthenticationHel
     return StandardResponse(success=True, data=config_data, message="Avatar configuration retrieved.")
 
 @social_marketing_router.post("/upload-swamiji-image", response_model=StandardResponse)
-async def upload_swamiji_image(file: UploadFile = File(...), admin_user: dict = Depends(AuthenticationHelper.verify_admin_access_strict)):
+async def upload_swamiji_image(
+    file: UploadFile, 
+    admin_user: dict = Depends(AuthenticationHelper.verify_admin_access_strict)
+):
     # REFRESH.MD: Restore filename null check (regression fix)
     if not file.filename:
         raise HTTPException(status_code=400, detail="No filename provided.")


### PR DESCRIPTION
This commit fixes a '422 Unprocessable Content' error in the Swamiji image upload endpoint. The function signature was changed from 'file: UploadFile = File(...)' to 'file: UploadFile', which correctly handles the multipart/form-data request without requiring a specific form field name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when uploading images by ensuring a proper error is returned if no filename is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->