### PR TITLE
fix(api): Correct Content-Type for file uploads

### DIFF
--- a/frontend/src/services/enhanced-api.js
+++ b/frontend/src/services/enhanced-api.js
@@ -17,12 +17,19 @@ class EnhancedAPI {
 
   async request(endpoint, options = {}) {
     const url = `${this.baseURL}${endpoint}`;
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.getAuthHeaders(),
+      ...(options.headers || {})
+    };
+
+    // CORE.MD: Do not set Content-Type for FormData, let the browser handle it.
+    if (options.body instanceof FormData) {
+      delete headers['Content-Type'];
+    }
+
     const config = {
-      headers: {
-        'Content-Type': 'application/json',
-        ...this.getAuthHeaders(),
-        ...(options.headers || {})
-      },
+      headers,
       credentials: 'include',
       ...options
     };
@@ -170,11 +177,7 @@ class EnhancedAPI {
   async uploadSwamjiImage(formData) {
     return this.request('/api/admin/social-marketing/upload-swamiji-image', {
       method: 'POST',
-      body: formData,
-      headers: {
-        // Don't set Content-Type for FormData, let browser set it
-        ...this.getAuthHeaders()
-      }
+      body: formData
     });
   }
 


### PR DESCRIPTION
This commit fixes the '422 Unprocessable Content' error on file uploads. The 'request' function in 'enhanced-api.js' is updated to conditionally remove the 'Content-Type' header for FormData requests, allowing the browser to set the correct 'multipart/form-data' header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of request headers for API calls, ensuring better support for file uploads and JSON data.
  * Streamlined image upload process for a more reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->