### PR TITLE
fix(core): Use relative imports for deployment

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -41,8 +41,9 @@ from schemas.social_media import (
     TikTokPlatformStatus,
     BasePlatformStatus,
 )
+# REFRESH.MD: Use a relative import for the avatar engine for deployment consistency.
 try:
-    from spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
+    from ..spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
     AVATAR_ENGINE_AVAILABLE = True
 except ImportError:
     AVATAR_ENGINE_AVAILABLE = False

--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -79,9 +79,9 @@ try:
 except ImportError:
     TIKTOK_SERVICE_AVAILABLE = False
 
-# REFRESH.MD: Import the new automation engine
+# REFRESH.MD: Use relative imports for deployment robustness
 try:
-    from backend.social_media_marketing_automation import SocialMediaMarketingEngine, get_social_media_engine
+    from ..social_media_marketing_automation import SocialMediaMarketingEngine, get_social_media_engine
     AUTOMATION_ENGINE_AVAILABLE = True
 except ImportError as e:
     AUTOMATION_ENGINE_AVAILABLE = False
@@ -93,12 +93,12 @@ except ImportError as e:
     def get_social_media_engine():
         raise HTTPException(status_code=501, detail="The Social Media Automation Engine is not available.")
 
-# REFRESH.MD: Import the new Supabase storage service
-from backend.services.supabase_storage_service import SupabaseStorageService, get_storage_service
+# REFRESH.MD: Use relative imports for deployment robustness
+from ..services.supabase_storage_service import SupabaseStorageService, get_storage_service
 
 # CORE.MD: Import the default voice ID for fallback
 # This import is no longer needed as frontend now sends the voice_id
-# from backend.spiritual_avatar_generation_engine import DEFAULT_VOICE_ID
+# from ..spiritual_avatar_generation_engine import DEFAULT_VOICE_ID
 
 
 # Initialize logger and router

--- a/backend/social_media_marketing_automation.py
+++ b/backend/social_media_marketing_automation.py
@@ -17,7 +17,7 @@ from fastapi import Depends
 # REFRESH.MD: Use relative imports for deployment robustness
 from ..core_foundation_enhanced import EnhancedSpiritualEngine, get_spiritual_engine
 from ..spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
-from ..schemas.social_media import SocialPlatform, ContentType, ContentPlan, PlanStatus
+from ..schemas.social_media import SocialPlatform, ContentType, ContentPlan
 from ..config.social_media_config import PLATFORM_CONFIGS, CONTENT_PROMPTS
 import db
 

--- a/backend/social_media_marketing_automation.py
+++ b/backend/social_media_marketing_automation.py
@@ -14,11 +14,11 @@ from pydantic import BaseModel, Field
 from fastapi import Depends
 
 # Local dependencies
-# REFRESH.MD: Use absolute imports for clarity and robustness
-from backend.core_foundation_enhanced import EnhancedSpiritualEngine, get_spiritual_engine
-from backend.spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
-from backend.schemas.social_media import SocialPlatform, ContentType, ContentPlan
-from backend.config.social_media_config import PLATFORM_CONFIGS, CONTENT_PROMPTS
+# REFRESH.MD: Use relative imports for deployment robustness
+from ..core_foundation_enhanced import EnhancedSpiritualEngine, get_spiritual_engine
+from ..spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
+from ..schemas.social_media import SocialPlatform, ContentType, ContentPlan, PlanStatus
+from ..config.social_media_config import PLATFORM_CONFIGS, CONTENT_PROMPTS
 import db
 
 # Initialize logger

--- a/backend/social_media_marketing_automation.py
+++ b/backend/social_media_marketing_automation.py
@@ -14,11 +14,11 @@ from pydantic import BaseModel, Field
 from fastapi import Depends
 
 # Local dependencies
-# REFRESH.MD: Use relative imports for deployment robustness
-from ..core_foundation_enhanced import EnhancedSpiritualEngine, get_spiritual_engine
-from ..spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
-from ..schemas.social_media import SocialPlatform, ContentType, ContentPlan
-from ..config.social_media_config import PLATFORM_CONFIGS, CONTENT_PROMPTS
+# REFRESH.MD: Use correct relative imports for sibling modules within the same package.
+from .core_foundation_enhanced import EnhancedSpiritualEngine, get_spiritual_engine
+from .spiritual_avatar_generation_engine import SpiritualAvatarGenerationEngine, get_avatar_engine
+from .schemas.social_media import SocialPlatform, ContentType, ContentPlan
+from .config.social_media_config import PLATFORM_CONFIGS, CONTENT_PROMPTS
 import db
 
 # Initialize logger

--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -16,8 +16,6 @@ import asyncio
 from fastapi import HTTPException, Depends
 import asyncpg
 
-# REFRESH.MD: Use relative imports for deployment robustness
-from ..services.supabase_storage_service import SupabaseStorageService, get_storage_service
 import db
 
 

--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -16,6 +16,8 @@ import asyncio
 from fastapi import HTTPException, Depends
 import asyncpg
 
+# REFRESH.MD: Use relative imports for deployment robustness
+from ..services.supabase_storage_service import SupabaseStorageService, get_storage_service
 import db
 
 
@@ -207,7 +209,8 @@ class SpiritualAvatarGenerationEngine:
 # --- FastAPI Dependency Injection ---
 _avatar_engine_instance = None
 
-def get_avatar_engine() -> SpiritualAvatarGenerationEngine:
+# REFRESH.MD: Corrected the function signature which was mistakenly altered
+def get_avatar_engine() -> "SpiritualAvatarGenerationEngine":
     """
     FastAPI dependency that provides a singleton instance of the avatar engine.
     """


### PR DESCRIPTION
Refactors absolute imports starting with 'from backend.' to relative imports (e.g., 'from ..services'). This resolves ModuleNotFoundErrors during deployment on platforms like Render where the top-level package structure is not recognized in the same way as in local development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal module import paths for better deployment stability.
  * Enhanced compatibility by refining a function's return type annotation.

No changes affecting user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->