### PR TITLE
fix(storage): Set upsert to string 'true' in Supabase upload

### DIFF
--- a/backend/services/supabase_storage_service.py
+++ b/backend/services/supabase_storage_service.py
@@ -58,7 +58,7 @@ class SupabaseStorageService:
 
         try:
             # The 'file_options' dictionary is crucial for setting the MIME type.
-            # 'upsert=True' means it will overwrite the file if it already exists.
+            # 'upsert="true"' means it will overwrite the file if it already exists.
             self.supabase.storage.from_(bucket_name).upload(
                 path=file_path_in_bucket,
                 file=file,

--- a/backend/services/supabase_storage_service.py
+++ b/backend/services/supabase_storage_service.py
@@ -62,7 +62,7 @@ class SupabaseStorageService:
             self.supabase.storage.from_(bucket_name).upload(
                 path=file_path_in_bucket,
                 file=file,
-                file_options={"content-type": content_type, "upsert": True}
+                file_options={"content-type": content_type, "upsert": "true"}
             )
             logger.info(f"Successfully uploaded file to Supabase bucket '{bucket_name}' at path '{file_path_in_bucket}'.")
             


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload reliability to storage by updating internal configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->