### PR TITLE
hotfix(avatar): Remove incorrect await from synchronous call

### DIFF
--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -96,8 +96,9 @@ class SpiritualAvatarGenerationEngine:
             file_name_in_bucket = f"public/generated_audio_{uuid.uuid4()}.mp3"
             bucket_name = "avatars"
 
-            # CORE.MD: Added 'await' as file upload is an async I/O operation.
-            public_url = await self.storage_service.upload_file(
+            # CORE.MD: Removed 'await' as the underlying Supabase client library's
+            # upload method is synchronous, not asynchronous.
+            public_url = self.storage_service.upload_file(
                 bucket_name=bucket_name,
                 file_path_in_bucket=file_name_in_bucket,
                 file=audio_content,


### PR DESCRIPTION
This commit fixes a TypeError in the avatar generation flow.

The storage_service.upload_file method is synchronous, but it was being called with wait. This has been corrected by removing the unnecessary wait keyword, resolving the runtime error and allowing the avatar generation to complete successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of audio generation by correcting file upload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->