### PR TITLE
hotfix(storage): Sanitize Supabase URL

### DIFF
--- a/backend/services/supabase_storage_service.py
+++ b/backend/services/supabase_storage_service.py
@@ -84,6 +84,9 @@ class SupabaseStorageService:
         
         try:
             response = self.supabase.storage.from_(bucket_name).get_public_url(file_path_in_bucket)
+            # REFRESH.MD: Strip trailing question marks from the URL to prevent validation issues with D-ID.
+            if isinstance(response, str):
+                return response.rstrip('?')
             return response
         except Exception as e:
             logger.error(f"Failed to get public URL from Supabase for path '{file_path_in_bucket}': {e}", exc_info=True)


### PR DESCRIPTION
This fixes a bug where Supabase would return a public URL with a trailing '?', causing D-ID API validation to fail. The get_public_url method now strips the trailing '?'.