### PR TITLE
feat(avatar): Default to male voice dynamically

### DIFF
--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -198,9 +198,13 @@ class SpiritualAvatarGenerationEngine:
             response.raise_for_status()
             voices_data = response.json().get("voices", [])
             
-            # Format the voices for the frontend
+            # REFRESH.MD: Format the voices for the frontend, including gender for better filtering.
             formatted_voices = [
-                {"id": voice["voice_id"], "name": voice["name"]}
+                {
+                    "id": voice["voice_id"],
+                    "name": voice["name"],
+                    "gender": voice.get("labels", {}).get("gender", "unknown")
+                }
                 for voice in voices_data
             ]
             logger.info(f"Successfully fetched {len(formatted_voices)} voices from ElevenLabs.")

--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -203,7 +203,8 @@ class SpiritualAvatarGenerationEngine:
                 {
                     "id": voice["voice_id"],
                     "name": voice["name"],
-                    "gender": voice.get("labels", {}).get("gender", "unknown")
+                    # CORE.MD: Normalize gender to lowercase to prevent case-sensitivity issues on the frontend.
+                    "gender": voice.get("labels", {}).get("gender", "unknown").lower()
                 }
                 for voice in voices_data
             ]

--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -203,8 +203,8 @@ class SpiritualAvatarGenerationEngine:
                 {
                     "id": voice["voice_id"],
                     "name": voice["name"],
-                    # CORE.MD: Normalize gender to lowercase to prevent case-sensitivity issues on the frontend.
-                    "gender": voice.get("labels", {}).get("gender", "unknown").lower()
+                    # CORE.MD: Normalize gender to lowercase and handle None values safely to prevent AttributeErrors.
+                    "gender": ((voice.get("labels") or {}).get("gender") or "unknown").lower()
                 }
                 for voice in voices_data
             ]

--- a/backend/spiritual_avatar_generation_engine.py
+++ b/backend/spiritual_avatar_generation_engine.py
@@ -198,16 +198,27 @@ class SpiritualAvatarGenerationEngine:
             response.raise_for_status()
             voices_data = response.json().get("voices", [])
             
-            # REFRESH.MD: Format the voices for the frontend, including gender for better filtering.
-            formatted_voices = [
-                {
+            # REFRESH.MD: Refactored to a for-loop for robust and readable parsing of voice data.
+            formatted_voices = []
+            for voice in voices_data:
+                labels = voice.get("labels")
+                gender_raw = "unknown"
+                # CORE.MD: Check if 'labels' is a dictionary to prevent AttributeErrors.
+                if isinstance(labels, dict):
+                    gender_raw = labels.get("gender")
+
+                # CORE.MD: Check if the final gender value is a string before calling .lower().
+                gender_str = "unknown"
+                if isinstance(gender_raw, str):
+                    gender_str = gender_raw
+
+                formatted_voices.append({
                     "id": voice["voice_id"],
                     "name": voice["name"],
-                    # CORE.MD: Normalize gender to lowercase and handle None values safely to prevent AttributeErrors.
-                    "gender": ((voice.get("labels") or {}).get("gender") or "unknown").lower()
-                }
-                for voice in voices_data
-            ]
+                    # This is now safe from all identified edge cases (None, non-dict, non-str).
+                    "gender": gender_str.lower()
+                })
+
             logger.info(f"Successfully fetched {len(formatted_voices)} voices from ElevenLabs.")
             return formatted_voices
 

--- a/frontend/src/components/admin/SwamjiAvatarPreview.jsx
+++ b/frontend/src/components/admin/SwamjiAvatarPreview.jsx
@@ -62,12 +62,12 @@ const SwamjiAvatarPreview = () => {
         }
         if (response.data.voices && response.data.voices.length > 0) {
             setVoices(response.data.voices);
-            // REFRESH.MD: Default to a suitable male voice like 'Prem'.
-            const defaultVoice = response.data.voices.find(v => v.name === 'Prem');
+            // REFRESH.MD: Default to the first available male voice for better suitability.
+            const defaultVoice = response.data.voices.find(v => v.gender === 'male');
             if (defaultVoice) {
                 setSelectedVoice(defaultVoice.id);
             } else {
-                setSelectedVoice(response.data.voices[0].id); // Fallback to the first voice
+                setSelectedVoice(response.data.voices[0].id); // Fallback to the first voice if no male voice is found
             }
         }
       } else {


### PR DESCRIPTION
This commit refactors the avatar voice selection to be more robust. The backend now fetches the 'gender' label for each voice from the ElevenLabs API. The frontend now defaults to the first available male voice, rather than relying on a hardcoded name. This ensures a suitable male voice is selected by default for the Swamiji avatar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice options now include gender information, enabling improved filtering and selection.

* **Bug Fixes**
  * Default voice selection now prioritizes the first male voice available; if none are found, the first voice in the list is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->