### PR TITLE
fix(inpainting): Correct mask_source to inpaint white areas

### DIFF
--- a/backend/services/stability_ai_service.py
+++ b/backend/services/stability_ai_service.py
@@ -79,7 +79,7 @@ class StabilityAiService:
             'mask_image': ('mask_image.png', mask_bytes, 'image/png')
         }
         data = {
-            'mask_source': 'MASK_IMAGE_BLACK',
+            'mask_source': 'MASK_IMAGE_WHITE', # CORE.MD: Corrected mask source. White areas should be inpainted.
             'text_prompts[0][text]': text_prompt,
             'cfg_scale': '7',
             'samples': '1',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image inpainting behavior so that white areas in the mask are now recognized as the regions to be inpainted. This change may affect how your mask images are interpreted during image editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->