### PR TITLE
Feat: Implement negative prompting to control clothing color

### DIFF
--- a/backend/services/stability_ai_service.py
+++ b/backend/services/stability_ai_service.py
@@ -54,7 +54,7 @@ class StabilityAiService:
             logger.info("Stability.ai service client closed.")
     
     # CORE.MD: Refactored from inpainting to a more suitable image-to-image generation.
-    async def generate_image_from_image(self, image_bytes: bytes, text_prompt: str, image_strength: float = 0.6) -> bytes:
+    async def generate_image_from_image(self, image_bytes: bytes, text_prompt: str, negative_prompt: Optional[str] = None, image_strength: float = 0.6) -> bytes:
         """
         Generates an image using the Stability.ai image-to-image endpoint,
         which is better suited for theme generation than masking.
@@ -88,11 +88,18 @@ class StabilityAiService:
             "image_strength": str(image_strength),
             "init_image_mode": "IMAGE_STRENGTH",
             "text_prompts[0][text]": text_prompt,
+            "text_prompts[0][weight]": 1.0,
             "cfg_scale": 7,
             "style_preset": "photographic",
             "samples": 1,
             "steps": 30,
         }
+        
+        # REFRESH.MD: Add negative prompt to the request if provided.
+        if negative_prompt:
+            data["text_prompts[1][text]"] = negative_prompt
+            data["text_prompts[1][weight]"] = -1.0
+
 
         try:
             client = await self.get_client()

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -108,12 +108,16 @@ class ThemeService:
             # CORE.MD: Use the correct key 'description' to access the theme details.
             # REFRESH.MD: Specify "full-body portrait" in the prompt to guide the AI away from close-ups.
             prompt = f"A full-body portrait, photorealistic, high-resolution image of a wise Indian spiritual master, Swamiji, with a gentle smile, {theme['description']}."
+            
+            # CORE.MD: Add a negative prompt to explicitly prevent the original orange robes from appearing.
+            negative_prompt = "orange, orange robes, orange color"
 
             # CORE.MD: Switched to the more powerful image-to-image generation.
-            # REFRESH.MD: Reverted image_strength to 0.45 for a better balance between face preservation and creative freedom for clothing.
+            # REFRESH.MD: Reverted image_strength to 0.45 for a better balance, now guided by the negative prompt.
             generated_image_bytes = await self.stability_service.generate_image_from_image(
                 image_bytes=resized_image_bytes,
                 text_prompt=prompt,
+                negative_prompt=negative_prompt,
                 image_strength=0.45,
             )
 

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -109,8 +109,11 @@ class ThemeService:
             # REFRESH.MD: Specify "full-body portrait" in the prompt to guide the AI away from close-ups.
             prompt = f"A full-body portrait, photorealistic, high-resolution image of a wise Indian spiritual master, Swamiji, with a gentle smile, {theme['description']}."
             
-            # CORE.MD: Add a negative prompt to explicitly prevent the original orange robes from appearing.
-            negative_prompt = "orange, orange robes, orange color"
+            # CORE.MD: Add a negative prompt to explicitly prevent the original orange robes from appearing,
+            # except on Thursdays when orange robes are part of the theme.
+            negative_prompt = None
+            if day_of_week != 3: # Thursday is weekday 3
+                negative_prompt = "orange, orange robes, orange color"
 
             # CORE.MD: Switched to the more powerful image-to-image generation.
             # REFRESH.MD: Reverted image_strength to 0.45 for a better balance, now guided by the negative prompt.


### PR DESCRIPTION
This adds support for negative prompts in the Stability.ai service and uses it in the ThemeService to prevent the original orange robes from appearing, ensuring the generated clothing matches the prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for negative prompts in image generation, allowing users to specify elements to avoid in generated images.

* **Enhancements**
  * Daily themed images now better exclude unwanted elements, such as orange robes, for improved visual results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->