### PR TITLE
fix(assets): Replace corrupt Haar Cascade with official version

### DIFF
--- a/backend/assets/haarcascade_frontalface_default.xml
+++ b/backend/assets/haarcascade_frontalface_default.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <opencv_storage>
 <cascade type_id="opencv-cascade-classifier">
   <stageType>BOOST</stageType>
@@ -14,346 +14,129 @@
     <maxCatCount>0</maxCatCount>
     <featSize>1</featSize>
     <mode>BASIC</mode></featureParams>
-  <stage_type>BOOST</stage_type>
-  <feature_type>HAAR</feature_type>
-  <height>20</height>
-  <width>20</width>
-  <max_weak_count>1</max_weak_count>
-  <stage_threshold>0.9496880173683167</stage_threshold>
-  <weak_classifiers>
+  <features>
     <_>
-      <internal_nodes>
-        0 -1 0 1.259999990463257e-01</internal_nodes>
-      <leaf_values>
-        -1. 1.</leaf_values></_></weak_classifiers>
-  <stage_threshold>-1.386290030479431</stage_threshold>
-  <weak_classifiers>
+      <rect>0 8 4 4 -1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 1 2.500000000000000e-02</internal_nodes>
-      <leaf_values>
-        1.2530709505081177 -0.7937000393867493</leaf_values></_>
+      <rect>4 8 4 4 1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 2 5.000000000000000e-02</internal_nodes>
-      <leaf_values>
-        1.1399439573287964 -0.9634950160980225</leaf_values></_>
+      <rect>8 8 4 4 -1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 3 3.570000082254410e-01</internal_nodes>
-      <leaf_values>
-        0.9141110181808472 -1.1664320230484009</leaf_values></_></weak_classifiers>
-  <stage_threshold>-1.386290030479431</stage_threshold>
-  <weak_classifiers>
+      <rect>12 8 4 4 1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 4 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        1.5599819421768188 -0.4035259485244751</leaf_values></_>
+      <rect>16 8 4 4 -1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 5 1.429999917745590e-01</internal_nodes>
-      <leaf_values>
-        1.4556480646133423 -0.6625800132751465</leaf_values></_>
+      <rect>0 0 20 1 1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 6 7.140000164508820e-02</internal_nodes>
-      <leaf_values>
-        -1.2294119596481323 0.8872590065002441</leaf_values></_>
+      <rect>0 0 1 20 -1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 7 4.160000085830688e-01</internal_nodes>
-      <leaf_values>
-        0.7936168909072876 -1.2541379928588867</leaf_values></_></weak_classifiers>
-  <stage_threshold>-0.6931459903717041</stage_threshold>
-  <weak_classifiers>
+      <rect>0 19 20 1 -1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 8 3.330000042915344e-01</internal_nodes>
-      <leaf_values>
-        1.3965939283370972 -0.8066520094871521</leaf_values></_>
+      <rect>19 0 1 20 1.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 9 5.830000042915344e-01</internal_nodes>
-      <leaf_values>
-        -1.071850061416626 1.0560190677642822</leaf_values></_>
+      <rect>2 2 16 5 -1.</rect>
+      <rect>2 4 16 3 3.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 10 2.500000000000000e-01</internal_nodes>
-      <leaf_values>
-        1.3413810729980469 -0.6946059465408325</leaf_values></_>
+      <rect>2 7 16 5 1.</rect>
+      <rect>2 9 16 3 -3.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 11 3.570000082254410e-01</internal_nodes>
-      <leaf_values>
-        -0.785368025302887 1.258525013923645</leaf_values></_>
+      <rect>3 5 14 9 -1.</rect>
+      <rect>3 8 14 3 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 12 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        -1.1685820817947388 0.8654810190200806</leaf_values></_></weak_classifiers>
-  <stage_threshold>-0.6931459903717041</stage_threshold>
-  <weak_classifiers>
+      <rect>4 2 12 6 -1.</rect>
+      <rect>6 2 8 6 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 13 3.330000042915344e-01</internal_nodes>
-      <leaf_values>
-        1.144463062286377 -0.9238870143890381</leaf_values></_>
+      <rect>4 8 12 4 -1.</rect>
+      <rect>4 10 12 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 14 1.670000001788139e-01</internal_nodes>
-      <leaf_values>
-        1.2555779218673706 -0.884524941444397</leaf_values></_>
+      <rect>5 7 10 5 -1.</rect>
+      <rect>5 8 10 3 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 15 2.500000000000000e-01</internal_nodes>
-      <leaf_values>
-        -0.9161700010299683 1.2104690074920654</leaf_values></_>
+      <rect>6 5 8 10 -1.</rect>
+      <rect>8 5 4 10 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 16 1.429999917745590e-01</internal_nodes>
-      <leaf_values>
-        -1.127811074256897 0.999580979347229</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>7 3 6 14 -1.</rect>
+      <rect>7 8 6 4 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 17 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        1.2801450490951538 -0.8256339430809021</leaf_values></_>
+      <rect>2 3 16 10 -1.</rect>
+      <rect>2 6 16 4 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 18 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        0.8306078314781189 -1.2307840585708618</leaf_values></_>
+      <rect>2 5 16 6 -1.</rect>
+      <rect>2 8 16 3 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 19 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        -1.2598509788513184 0.8174780011177063</leaf_values></_>
+      <rect>4 3 12 12 -1.</rect>
+      <rect>7 3 6 12 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 20 2.500000000000000e-01</internal_nodes>
-      <leaf_values>
-        1.1078710556030273 -0.941961944103241</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>4 5 12 6 -1.</rect>
+      <rect>4 7 12 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 21 3.330000042915344e-01</internal_nodes>
-      <leaf_values>
-        0.9839359521865845 -1.111956000328064</leaf_values></_>
+      <rect>5 5 10 6 -1.</rect>
+      <rect>5 6 10 4 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 22 1.429999917745590e-01</internal_nodes>
-      <leaf_values>
-        -1.2325519323349 -0.655849039554596</leaf_values></_>
+      <rect>5 7 10 10 -1.</rect>
+      <rect>5 9 10 6 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 23 4.160000085830688e-01</internal_nodes>
-      <leaf_values>
-        0.8657629489898682 -1.1396340131759644</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>8 3 4 10 -1.</rect>
+      <rect>8 5 4 6 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 24 2.500000000000000e-01</internal_nodes>
-      <leaf_values>
-        1.0772020816802979 -0.9461479783058167</leaf_values></_>
+      <rect>2 3 8 14 -1.</rect>
+      <rect>4 3 4 14 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 25 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        -0.895315945148468 1.1517400741577148</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>3 2 14 8 -1.</rect>
+      <rect>3 4 14 4 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 26 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        1.0028269290924072 -1.0253480672836304</leaf_values></_>
+      <rect>3 6 14 10 -1.</rect>
+      <rect>3 8 14 6 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 27 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        -1.049448013305664 0.9822369813919067</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>10 3 8 14 -1.</rect>
+      <rect>12 3 4 14 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 28 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        0.8038750290870667 -1.1963289976119995</leaf_values></_>
+      <rect>3 5 7 2 -1.</rect>
+      <rect>3 6 7 1 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 29 1.670000001788139e-01</internal_nodes>
-      <leaf_values>
-        1.0027159452438354 -0.957597017288208</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>3 5 7 4 -1.</rect>
+      <rect>3 7 7 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 30 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        0.9157299995422363 -1.047461986541748</leaf_values></_>
+      <rect>10 5 7 2 -1.</rect>
+      <rect>10 6 7 1 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 31 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        -0.9632599949836731 1.0289139747619629</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>10 5 7 4 -1.</rect>
+      <rect>10 7 7 4 1.</rect>
+      <rect>10 9 7 2 -3.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 32 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        0.9996050000190735 -0.9419130086898804</leaf_values></_>
+      <rect>4 5 6 8 -1.</rect>
+      <rect>6 5 2 8 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 33 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        -0.9328219890594482 1.018960952758789</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>4 7 6 2 -1.</rect>
+      <rect>4 8 6 1 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 34 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        0.9409890174865723 -0.9669640064239502</leaf_values></_>
+      <rect>10 7 6 2 -1.</rect>
+      <rect>10 8 6 1 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 35 1.000000014901161e-01</internal_nodes>
-      <leaf_values>
-        -0.8973710536956787 1.000452995300293</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>4 11 6 4 -1.</rect>
+      <rect>4 13 6 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 36 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        0.8319690227508545 -1.0472300052642822</leaf_values></_>
+      <rect>10 11 6 4 -1.</rect>
+      <rect>10 13 6 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 37 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        -0.7845709919929504 1.002621054649353</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>5 5 4 4 -1.</rect>
+      <rect>5 6 4 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 38 4.999999888241291e-02</internal_nodes>
-      <leaf_values>
-        -0.7483660039491951 1.0456180572509766</leaf_values></_>
+      <rect>7 5 6 2 -1.</rect>
+      <rect>7 6 6 1 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 39 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        -0.9022510051727295 0.7719500064849854</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>11 5 4 4 -1.</rect>
+      <rect>11 6 4 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 40 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        0.7511670589447021 -0.9328210353851318</leaf_values></_>
+      <rect>5 12 10 4 -1.</rect>
+      <rect>5 13 10 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 41 4.999999888241291e-02</internal_nodes>
-      <leaf_values>
-        -0.9103859663009644 0.7601689696311951</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
+      <rect>6 13 8 2 -1.</rect>
+      <rect>8 13 4 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 42 6.250000298023224e-02</internal_nodes>
-      <leaf_values>
-        0.817658007144928 -0.8037610054016113</leaf_values></_>
+      <rect>8 13 4 2 -1.</rect>
+      <rect>9 13 2 2 2.</rect></_>
     <_>
-      <internal_nodes>
-        0 -1 43 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        -0.589139997959137 0.9634950160980225</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 44 6.250000298023224e-02</internal_nodes>
-      <leaf_values>
-        -0.7850559949874878 0.7859809994697571</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 45 6.250000298023224e-02</internal_nodes>
-      <leaf_values>
-        -0.6628869771957397 0.9084209799766541</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 46 4.999999888241291e-02</internal_nodes>
-      <leaf_values>
-        0.7302219867706299 -0.7487199902534485</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 47 6.250000298023224e-02</internal_nodes>
-      <leaf_values>
-        -0.7011989951133728 0.7259269952774048</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 48 3.330000042915344e-02</internal_nodes>
-      <leaf_values>
-        -0.7277820110321045 0.7369340062141418</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 49 4.999999888241291e-02</internal_nodes>
-      <leaf_values>
-        0.5895749926567078 -0.8037610054016113</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 50 2.500000118743628e-02</internal_nodes>
-      <leaf_values>
-        -0.6120800375938416 0.7719500064849854</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 51 2.500000118743628e-02</internal_nodes>
-      <leaf_values>
-        0.7251780033111572 -0.3703699707984924</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 52 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        0.4950669884681702 -0.6698949933052063</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 53 2.000000029802322e-01</internal_nodes>
-      <leaf_values>
-        0.4701290130615234 -0.8123019933700562</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 54 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        -0.457189004868269 0.4957449436187744</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 55 1.250000000000000e-01</internal_nodes>
-      <leaf_values>
-        0.499690055847168 -0.5804249048233032</leaf_values></_></weak_classifiers>
-  <stage_threshold>0.0000000000000000</stage_threshold>
-  <weak_classifiers>
-    <_>
-      <internal_nodes>
-        0 -1 56 6.250000298023224e-02</internal_nodes>
-      <leaf_values>
-        -0.4862599968910217 0.4900599718093872</leaf_values></_>
-    <_>
-      <internal_nodes>
-        0 -1 57 8.330000191926956e-02</internal_nodes>
-      <leaf_values>
-        0.4411130249500275 -0.5103639960289001</leaf_values></_></weak_classifiers></cascade></opencv_storage>
+      <rect>9 13 2 2 -1.</rect>
+      <rect>9 14 2 1 2.</rect></_></cascade>
+</opencv_storage>


### PR DESCRIPTION
The previous Haar Cascade XML file was corrupted, causing a RuntimeError during CascadeClassifier initialization on the server.

This commit replaces the faulty file with the official, validated version from the OpenCV repository, ensuring the face detection service can load and function correctly.