### PR TITLE
fix(deploy): Install system dependencies for OpenCV

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: jyotiflow-backend
     env: python
-    buildCommand: "cd backend && pip install -r requirements.txt && python3 auto_deploy_migration.py && python3 populate_service_endpoints.py"
+    buildCommand: "apt-get update && apt-get install -y libgl1-mesa-glx && cd backend && pip install -r requirements.txt && python3 auto_deploy_migration.py && python3 populate_service_endpoints.py"
     startCommand: "cd backend && uvicorn main:app --host 0.0.0.0 --port $PORT"
     envVars:
       - key: PYTHON_VERSION


### PR DESCRIPTION
Adds libgl1-mesa-glx via apt-get in the build command to ensure OpenCV can run on the Render.com native environment.

This resolves the SystemError: <class 'cv2.CascadeClassifier'> returned a result with an exception set which was caused by missing system-level libraries required by OpenCV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service build process to include system package updates and installation of additional system libraries for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->