### PR TITLE
fix(deploy): Install all required system dependencies for OpenCV

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: jyotiflow-backend
     env: python
-    buildCommand: "apt-get update && apt-get install -y libgl1-mesa-glx && cd backend && pip install -r requirements.txt && python3 auto_deploy_migration.py && python3 populate_service_endpoints.py"
+    buildCommand: "apt-get update && apt-get install -y libgl1-mesa-glx libglib2.0-0 libsm6 libxext6 libxrender-dev && cd backend && pip install -r requirements.txt && python3 auto_deploy_migration.py && python3 populate_service_endpoints.py"
     startCommand: "cd backend && uvicorn main:app --host 0.0.0.0 --port $PORT"
     envVars:
       - key: PYTHON_VERSION


### PR DESCRIPTION
This commit provides a comprehensive fix for the server environment by installing all necessary system-level libraries (libgl1-mesa-glx, libglib2.0-0, etc.) required for opencv-python-headless to function correctly on Render.com's native environment.

This is the definitive solution to resolve the SystemError from cv2.CascadeClassifier and ensure the application runs reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system dependencies for the backend service to improve compatibility and support for additional features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->