### PR TITLE
fix(cors): Add backend URL to allowed origins

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -303,7 +303,10 @@ app = FastAPI(
 # --- CORS Middleware (English & Tamil) ---
 # REFRESH.MD: Restore dynamic CORS origins for different environments while ensuring
 # the production frontend is always allowed. This is a more robust and secure approach.
-ALWAYS_ALLOW_ORIGINS = ["https://jyotiflow-ai-frontend.onrender.com"]
+ALWAYS_ALLOW_ORIGINS = [
+    "https://jyotiflow-ai-frontend.onrender.com",
+    "https://jyotiflow-ai.onrender.com"
+]
 
 def get_cors_origins():
     """Get CORS origins based on environment"""


### PR DESCRIPTION
This commit resolves the CORS policy error that was blocking requests from the frontend to the backend.

The backend URL https://jyotiflow-ai.onrender.com is now added to the ALWAYS_ALLOW_ORIGINS list in main.py, ensuring that the frontend can securely communicate with the backend API.

This is part of a combined fix that also addresses the OpenCV server environment issue.