### PR TITLE
CRITICAL FIX: Remove cv2 import causing 501 error

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -8,7 +8,6 @@ It now uses advanced image masking to preserve Swamiji's head while changing the
 import logging
 from datetime import datetime
 import uuid
-import cv2
 import numpy as np
 import httpx
 from fastapi import HTTPException, Depends


### PR DESCRIPTION
- Removed import cv2 from theme_service.py line 11
- This was causing ThemeService import failure on server
- Now service should load correctly and fix 501 error