### PR TITLE
Fix StabilityAI 400 Bad Request: Remove invalid style_preset

### DIFF
--- a/backend/services/stability_ai_service.py
+++ b/backend/services/stability_ai_service.py
@@ -90,7 +90,6 @@ class StabilityAiService:
             "text_prompts[0][text]": text_prompt,
             "text_prompts[0][weight]": 1.0,
             "cfg_scale": 10,
-            "style_preset": "photographic",
             "samples": 1,
             "steps": 40,
         }
@@ -174,7 +173,6 @@ class StabilityAiService:
             "cfg_scale": 10,
             "height": 1024,
             "width": 1024,
-            "style_preset": "photographic",
             "samples": 1,
             "steps": 30,
         }


### PR DESCRIPTION
- Removed style_preset 'photographic' from API requests
- This was causing 400 Bad Request errors from StabilityAI API
- Fixed both text-to-image and image-to-image/masking endpoints
- API now uses default style without preset parameter