### PR TITLE
fix: use image/* accept header for stability.ai compatibility

### DIFF
--- a/backend/services/stability_ai_service.py
+++ b/backend/services/stability_ai_service.py
@@ -79,7 +79,7 @@ class StabilityAiService:
         
         headers = {
             "Authorization": f"Bearer {self.api_key}",
-            "Accept": "image/*" # Request any image format from Stability.ai
+            "Accept": "image/*, application/json" # Request images on success, JSON on errors
         }
 
         # REFRESH.MD: FIX - Correctly format the files for httpx multipart/form-data.

--- a/backend/services/stability_ai_service.py
+++ b/backend/services/stability_ai_service.py
@@ -79,7 +79,7 @@ class StabilityAiService:
         
         headers = {
             "Authorization": f"Bearer {self.api_key}",
-            "Accept": "image/png, application/json" # Request the image directly, but also accept JSON for errors.
+            "Accept": "image/*" # Request any image format from Stability.ai
         }
 
         # REFRESH.MD: FIX - Correctly format the files for httpx multipart/form-data.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Stability.ai inpainting API by allowing responses in any image format, not just PNG.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->