### PR TITLE
REVERT: back to inpainting - img2img changing face identity

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -141,7 +141,9 @@ class ThemeService:
         try:
             base_image_bytes, _ = await self._get_base_image_data()
             logger.info(f"Base image loaded: {len(base_image_bytes)/1024:.1f}KB")
-            # CORE.MD: Following user guide - img2img approach for identity preservation (no masks needed)
+            # CORE.MD: REVERT - img2img changing face, back to inpainting with face protection mask
+            head_mask_bytes = self._create_head_mask(base_image_bytes)
+            logger.info(f"Head mask created: {len(head_mask_bytes)/1024:.1f}KB")
 
             if custom_prompt:
                 theme_description = custom_prompt
@@ -157,13 +159,12 @@ class ThemeService:
             logger.info(f"Final prompt generated: {final_prompt}")
             negative_prompt = "blurry, low-resolution, text, watermark, ugly, deformed, disfigured, poor anatomy, bad hands, extra limbs, cartoon, 3d render, duplicate head, two heads, distorted face"
 
-            # CORE.MD: USER GUIDE APPROACH - img2img with moderate strength for background/attire change
-            # "Base Swamiji Image + Prompt → Stability.ai (img2img mode) → Same face, new background"
-            image_bytes = await self.stability_service.generate_image_to_image(
+            # CORE.MD: BACK TO INPAINTING - img2img was changing face, inpainting protects face with mask
+            image_bytes = await self.stability_service.generate_image_with_mask(
                 init_image_bytes=base_image_bytes,
+                mask_image_bytes=head_mask_bytes,
                 text_prompt=final_prompt,
-                negative_prompt=negative_prompt,
-                strength=0.65  # Increased to 0.65 to ensure clothing/attire changes (background changing, need more for attire)
+                negative_prompt=negative_prompt
             )
             return image_bytes, final_prompt
 


### PR DESCRIPTION
- img2img with any strength changes face (user feedback confirmed)
- Face identity preservation is critical requirement
- Inpainting with mask protects face area completely
- Only changes body/background, preserves exact face
- This matches original user requirements for identity preservation