### PR TITLE
fix: Enhance background transformation with stronger img2img approach

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -156,9 +156,9 @@ class ThemeService:
 
     async def generate_themed_image_bytes(self, custom_prompt: Optional[str] = None) -> Tuple[bytes, str]:
         """
-        Generates themed image using img2img approach with optimal strength for natural results.
-        Uses enhanced identity preservation prompts to maintain exact facial features, hair, and beard.
-        Returns a tuple of (image_bytes, final_prompt) with 60% transformation for visible changes.
+        Generates themed image using img2img approach with strong background transformation.
+        Uses balanced prompts to preserve face while completely changing background and clothing.
+        Returns a tuple of (image_bytes, final_prompt) with 75% transformation for visible background changes.
         """
         try:
             base_image_bytes, _ = await self._get_base_image_data()
@@ -173,18 +173,18 @@ class ThemeService:
                 theme_description = theme['description']
                 logger.info(f"Using daily theme for {['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'][day_of_week]}: {theme.get('name', 'Unknown')} - {theme_description}")
 
-            # CORE.MD: OPTIMAL IMG2IMG - Natural proportions with enhanced identity preservation prompts
-            final_prompt = f"EXACT SAME PERSON: A photorealistic portrait of the IDENTICAL wise Indian spiritual master, {theme_description}. PRESERVE exact facial features, same face shape, same eyes, same nose, same mouth, same skin tone, same facial structure, IDENTICAL hair style, SAME hair color, EXACT mustache/beard style, SAME facial hair shape and length, SAME head hair length and texture. ONLY change background and clothing. Professional photography, detailed textures, vibrant colors."
+            # CORE.MD: BACKGROUND TRANSFORMATION - Stronger transformation with face preservation balance
+            final_prompt = f"TRANSFORM BACKGROUND COMPLETELY: A photorealistic portrait of a wise Indian spiritual master, {theme_description}. Keep the same person's face, maintain beard and hair, but COMPLETELY CHANGE the background setting, environment, and clothing. New location, new surroundings, new attire to match the theme. Professional photography, detailed textures, vibrant colors."
             logger.info(f"Final prompt generated: {final_prompt}")
-            negative_prompt = "blurry, low-resolution, text, watermark, ugly, deformed, disfigured, poor anatomy, bad hands, extra limbs, cartoon, 3d render, duplicate head, two heads, distorted face, different person, changed facial features, different face shape, different eyes, different nose, different mouth, face replacement, face swap, altered facial structure, different beard style, different mustache, face hallucination, changed hair style, different hair color, bald, clean shaven, hair transformation, beard removal, mustache removal, different hair length, altered hair texture, hair style change, facial hair modification"
+            negative_prompt = "blurry, low-resolution, text, watermark, ugly, deformed, disfigured, poor anatomy, bad hands, extra limbs, cartoon, 3d render, duplicate head, two heads, distorted face, different person, changed facial features, different face shape, different eyes, different nose, different mouth, face replacement, face swap, altered facial structure, different beard style, different mustache, face hallucination, original background, unchanged background, same setting, no transformation"
 
-            # CORE.MD: IMG2IMG OPTIMAL STRENGTH - Natural head-body proportions with strong identity preservation
-            logger.info("Using img2img with 0.6 strength for natural proportions and enhanced identity preservation")
+            # CORE.MD: STRONGER TRANSFORMATION - Higher strength for visible background changes
+            logger.info("Using img2img with 0.75 strength for stronger background transformation while preserving face")
             image_bytes = await self.stability_service.generate_image_to_image(
                 init_image_bytes=base_image_bytes,
                 text_prompt=final_prompt,
                 negative_prompt=negative_prompt,
-                strength=0.6  # Optimal strength: 60% transformation, 40% preservation
+                strength=0.75  # Stronger transformation: 75% change, 25% preservation
             )
             return image_bytes, final_prompt
 


### PR DESCRIPTION
- Increased strength from 0.6 to 0.75 for more visible changes
- Rebalanced prompts: TRANSFORM BACKGROUND COMPLETELY directive
- Removed overly conservative identity preservation terms
- Added anti-static negative prompts: original background, unchanged background
- Focus on complete background/environment/clothing transformation
- Maintain face preservation without being too conservative

Fixes issue where backgrounds were not changing from original photo.