### PR TITLE
fix: Switch to control mode for EXACT original feature preservation

### DIFF
--- a/backend/services/deep_image_ai_service.py
+++ b/backend/services/deep_image_ai_service.py
@@ -72,9 +72,9 @@ class DeepImageAiService:
                 "Content-Type": "application/json"
             }
             
-            # Deep Image AI payload with EXACT original feature preservation
-            # Enhanced description for strict original feature retention
-            enhanced_description = f"PRESERVE EXACT ORIGINAL: {theme_description}. Keep identical hair length, identical beard pattern, identical facial features from uploaded photo. Do not add extra hair, do not modify beard length, do not change facial hair style. Only change background environment and clothing to match theme."
+            # Deep Image AI payload with CONTROL mode for EXACT original preservation
+            # Use control mode instead of face mode for better feature retention
+            enhanced_description = f"Transform background to: {theme_description}. Change only background environment and clothing to match spiritual theme. Professional portrait photography, realistic lighting, detailed textures."
             
             payload = {
                 "url": image_url,
@@ -83,8 +83,8 @@ class DeepImageAiService:
                 "background": {
                     "generate": {
                         "description": enhanced_description,
-                        "adapter_type": "face",  # Use face from input image
-                        "face_id": True,         # Preserve detailed facial features EXACTLY
+                        "adapter_type": "control",  # Use control mode for better preservation
+                        "controlnet_conditioning_scale": 0.85,  # High preservation rate (85%)
                         "model_type": model_type # Realistic model for portraits
                     }
                 },

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -202,9 +202,9 @@ class ThemeService:
             # Fallback to Stability AI if Deep Image AI is not available or fails
             logger.info("🔄 Falling back to Stability AI img2img approach")
             
-            # Enhanced prompts for Stability AI fallback
-            stability_prompt = f"((COMPLETELY TRANSFORM background: {theme_description}, spiritual environment, dramatic scene change)), South Indian spiritual guru with long hair and thick beard (mudi, thadi), (PRESERVE EXACT original face details:1.5), (same beard pattern:1.4), (same facial expression:1.4), (same hair style:1.3), same pose, NEVER change the face. Professional portrait photography, realistic style, detailed textures."
-            negative_prompt = "different person, face change, facial modification, altered features, different beard, different hair, hair color change, bald, clean shaven, face replacement, face swap, AI hallucination, changed facial expression, different eyes, different nose, different mouth, altered facial structure, original background, unchanged background, same setting, indoor background, wall background, blurry, low-resolution, text, watermark, ugly, deformed, poor anatomy, cartoon, 3d render"
+            # Enhanced prompts for Stability AI fallback with strict original preservation
+            stability_prompt = f"((COMPLETELY TRANSFORM background: {theme_description}, spiritual environment, dramatic scene change)), (PRESERVE EXACT original person:1.5), (same facial features:1.4), (same beard length:1.4), (same hair style:1.3), (original mudi and thadi:1.4), same pose, NEVER change the face or hair. Professional portrait photography, realistic style, detailed textures."
+            negative_prompt = "different person, face change, facial modification, altered features, different beard, different hair, hair color change, bald, clean shaven, face replacement, face swap, AI hallucination, changed facial expression, different eyes, different nose, different mouth, altered facial structure, original background, unchanged background, same setting, indoor background, wall background, extra hair, long hair, added beard, modified beard, longer beard, different hair length, extra facial hair, blurry, low-resolution, text, watermark, ugly, deformed, poor anatomy, cartoon, 3d render"
 
             image_bytes = await self.stability_service.generate_image_to_image(
                 init_image_bytes=base_image_bytes,


### PR DESCRIPTION
- Change adapter_type from 'face' to 'control' for better preservation
- Add controlnet_conditioning_scale: 0.85 for high retention rate
- Enhanced negative prompts to prevent extra hair/beard additions
- Strict original mudi and thadi preservation
- Fallback prompts also enhanced for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved avatar generation to better preserve original facial features and hair/beard details when applying themed transformations.
  * Refined image generation prompts to enforce stricter identity retention, minimizing unintended changes to facial hair, hairstyle, and overall appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->