### PR TITLE
CLARIFY: Revert to face-only preservation, exclude background from mask

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -71,14 +71,14 @@ class ThemeService:
         Returns:
             bytes: PNG mask image as bytes
             
-        Mask Strategy (OPTION 5+6 ULTIMATE COMBINATION + USER FEEDBACK):
+        Mask Strategy (OPTION 5+6 ULTIMATE COMBINATION + USER CLARIFICATION):
         - Ultra-extended soft gradient mask with 3-zone blending + AI color analysis + precise color injection
-        - Inner zone (black): ENTIRE SCENE within red circle preserved (face + background + trees + all elements)
-        - Middle zone (dark gray): 75% preserve, 25% blend for smooth transitions around scene edges
+        - Inner zone (black): PRECISE FACE-ONLY preservation (head/facial features only, background can change)
+        - Middle zone (dark gray): 75% preserve, 25% blend for smooth transitions around face edges
         - Outer zone (medium gray): ULTRA-extended 40% neck/chest coverage for maximum skin tone reference
         - AI color analysis: Extract exact RGB values from face area and convert to descriptive terms
         - Color injection: Inject analyzed skin tone descriptions directly into transformation prompts
-        - White areas: Complete transformation freedom for distant background/clothes with color-matched body
+        - White areas: Complete transformation freedom for background/clothes/scenery with color-matched body
         """
         # Create a white background (transform everything by default)
         mask = Image.new('L', (image_width, image_height), 255)  # 'L' = grayscale, 255 = white
@@ -100,12 +100,12 @@ class ThemeService:
         
         # 🎨 SOFT GRADIENT MASK: Create natural blending for head-body integration
         
-        # Step 1: Create expanded scene preservation zone (pure preservation - black)
-        # USER FEEDBACK: Preserve entire scene within red circle, including background behind face
-        inner_face_left = face_left - int(face_width * 0.05)   # EXPAND by 5% (was shrink 10%)
-        inner_face_top = face_top - int(face_height * 0.05)    # EXPAND by 5% (was shrink 10%)
-        inner_face_right = face_right + int(face_width * 0.05) # EXPAND by 5% (was shrink 10%)
-        inner_face_bottom = face_bottom + int(face_height * 0.05) # EXPAND by 5% (was shrink 10%)
+        # Step 1: Create PRECISE FACE-ONLY preservation zone (pure preservation - black)
+        # USER CLARIFICATION: "thalaiya maddum thantha ok" - preserve ONLY head/face, NOT background
+        inner_face_left = face_left + int(face_width * 0.02)   # Slight shrink by 2% - precise face boundaries
+        inner_face_top = face_top + int(face_height * 0.02)    # Slight shrink by 2% - precise face boundaries
+        inner_face_right = face_right - int(face_width * 0.02) # Slight shrink by 2% - precise face boundaries  
+        inner_face_bottom = face_bottom - int(face_height * 0.02) # Slight shrink by 2% - precise face boundaries
         
         # Ensure inner boundaries stay within image dimensions
         inner_face_left = max(0, inner_face_left)
@@ -140,7 +140,7 @@ class ThemeService:
         mask.save(mask_buffer, format='PNG')
         mask_bytes = mask_buffer.getvalue()
         
-        logger.info(f"🎨 SCENE PRESERVATION MASK: {image_width}x{image_height} | Preserved scene: {inner_face_right-inner_face_left}x{inner_face_bottom-inner_face_top} (face+background) | Ultra blend zone: {outer_face_right-outer_face_left}x{outer_face_bottom-outer_face_top} (40% neck coverage) | Mask size: {len(mask_bytes)/1024:.1f}KB")
+        logger.info(f"🎨 FACE-ONLY PRESERVATION MASK: {image_width}x{image_height} | Preserved face: {inner_face_right-inner_face_left}x{inner_face_bottom-inner_face_top} (head only, background transforms) | Ultra blend zone: {outer_face_right-outer_face_left}x{outer_face_bottom-outer_face_top} (40% neck coverage) | Mask size: {len(mask_bytes)/1024:.1f}KB")
         return mask_bytes
 
     def _analyze_face_skin_color(self, image_bytes: bytes) -> str:
@@ -391,7 +391,7 @@ class ThemeService:
         - Face preservation mask: BLACK (preserve face) + WHITE (transform clothes/background)
         - 100% surgical precision - face pixels never touched, everything else free to transform
         - No conflicting prompts - mask handles preservation, prompts focus on transformation  
-        - Option 5+6 Ultimate + User Feedback: Scene preservation mask + AI color analysis + precise color injection (preserves entire scene within red circle)
+        - Option 5+6 Ultimate + User Clarification: Face-only preservation mask + AI color analysis + precise color injection (preserves head only, background transforms)
         - Enhanced theme descriptions with rich details (clothing, background, lighting, atmosphere)
         - Theme day selection for testing all 7 daily themes
         - No strength limitations - mask provides absolute control


### PR DESCRIPTION
🎯 USER CLARIFICATION IMPLEMENTED: 'thalaiya maddum thantha ok' - preserve ONLY head/face

USER FEEDBACK CLARIFIED:
- Previous expansion preserved face + background trees (too much preservation)
- User wants: Face/head preserved, background should transform with theme
- 'Background varama thalaiya maddum thantha ok' = Only head without background

PRECISE FACE-ONLY PRESERVATION:

1. REVERTED INNER ZONE EXPANSION:
   - OLD: EXPAND by 5% beyond face (included background trees/foliage)
   - NEW: SHRINK by 2% within face boundaries (precise face-only preservation)
   - RESULT: Background behind face now transforms with themes

2. UPDATED PRESERVATION STRATEGY:
   - Inner zone (black): PRECISE face boundaries only (eyes, nose, mouth, beard)
   - Background trees/foliage: Now transformable (not preserved)
   - Outer zones: Still provide color matching for skin tone consistency
   - White areas: Complete freedom for background/scenery transformation

3. TECHNICAL CHANGES:
   - inner_face_left: face_left + 2% (was face_left - 5%)
   - inner_face_top: face_top + 2% (was face_top - 5%)
   - inner_face_right: face_right - 2% (was face_right + 5%)
   - inner_face_bottom: face_bottom - 2% (was face_bottom + 5%)

4. DOCUMENTATION UPDATES:
   - Mask strategy: 'PRECISE FACE-ONLY preservation'
   - Logging: 'head only, background transforms'
   - Comments: 'preserve ONLY head/face, NOT background'

EXPECTED RESULTS:
- Perfect face preservation: facial features unchanged
- Background transformation: trees/foliage change with themes
- Natural composition: face preserved, scenery transforms thematically
- User satisfaction: exactly what was requested - face only

This implements the precise user clarification: preserve face, transform background!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated face preservation to focus on the precise face area (head/facial features), allowing the background to transform.

* **Documentation**
  * Clarified user feedback and descriptions to emphasize face-only preservation rather than entire scene preservation.
  * Updated inpainting prompt documentation to reflect the new mask strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->