### PR TITLE
🚨 API FIX: Remove unsupported cfg_scale parameter

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -531,8 +531,7 @@ class ThemeService:
                 init_image_bytes=base_image_bytes,
                 text_prompt=transformation_prompt,
                 negative_prompt=negative_prompt,
-                strength=validated_strength,  # Dynamic strength with validation (0.25-0.35 range)
-                cfg_scale=7                   # Your suggested cfg_scale for better guidance
+                strength=validated_strength  # Dynamic strength with validation (0.25-0.35 range)
             )
             
             logger.info("✅ IMG2IMG SUCCESS: Natural face preservation with low strength + perfect theme transformation")


### PR DESCRIPTION
CRITICAL ERROR RESOLVED:
❌ TypeError: StabilityAiService.generate_image_to_image() got unexpected keyword argument 'cfg_scale'

ROOT CAUSE:
- StabilityAiService.generate_image_to_image() only accepts: init_image_bytes, text_prompt, negative_prompt, strength
- cfg_scale parameter is NOT supported by this method
- Was causing 500 Internal Server Error on all image generation requests

SOLUTION:
✅ Removed cfg_scale=7 parameter from generate_image_to_image() call ✅ Method now uses only supported parameters
✅ Dynamic strength validation still intact (0.25-0.35 range)

TECHNICAL DETAILS:
- Checked StabilityAiService method signature (lines 158-164)
- cfg_scale only supported by generate_image_with_mask() method
- img2img uses different API endpoint that doesn't accept cfg_scale

This fixes the production error and allows image generation to work! 🎯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated image generation settings for themed images to improve consistency. No visible changes in user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->