### PR TITLE
fix: Resolve daily theme variations not working due to custom prompt …

### DIFF
--- a/frontend/src/components/admin/SwamjiAvatarPreview.jsx
+++ b/frontend/src/components/admin/SwamjiAvatarPreview.jsx
@@ -97,7 +97,7 @@ const SwamjiAvatarPreview = () => {
       setFinalVideo(null);
 
       const response = await enhanced_api.generateImagePreview({
-        custom_prompt: customPrompt || promptText || null, // Pass null to let the backend decide the daily theme
+        custom_prompt: customPrompt || null, // 🔧 FIXED: Don't use promptText for daily themes
         theme_day: themeDay, // Pass the theme day override
         timestamp: Date.now() // Cache busting
       });
@@ -361,7 +361,7 @@ const SwamjiAvatarPreview = () => {
                   />
                 </div>
                 <button
-                  onClick={() => generateImagePreview(promptText)}
+                  onClick={() => generateImagePreview(promptText || null)} // 🔧 FIXED: Only pass promptText if it has content
                   disabled={isGenerating}
                   className="w-full bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center justify-center space-x-2"
                 >


### PR DESCRIPTION
…override

🔧 CRITICAL BUG FIX:
- Fixed daily theme generation being overridden by previous promptText
- 'Generate Today's Daily Theme' was using old promptText instead of daily themes
- This caused same background/clothes instead of daily variations

❌ BEFORE (Broken Logic):
custom_prompt: customPrompt || promptText || null
- promptText contained previous generation result ('Daily theme generated successfully')
- This overrode daily theme selection, causing same image every time

✅ AFTER (Fixed Logic):
custom_prompt: customPrompt || null
- Only uses customPrompt when explicitly passed
- Daily theme generation now properly uses backend theme selection
- Each day (Monday-Sunday) will have different backgrounds and clothes

🎯 EXPECTED RESULTS:
- Monday: White robes + Himalayan mountains (Meditative)
- Tuesday: Maroon robes + Ashram hall (Teaching)
- Wednesday: Green kurta + Forest setting (Wisdom)
- Thursday: Blue kurta + Sacred river (Thankful)
- Friday: Golden robes + Temple courtyard (Festive)
- Saturday: Gray robes + Cave setting (Silent)
- Sunday: Cream dhoti + Ocean beach (Serene)

This fixes the core issue where daily themes weren't working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt handling to ensure only valid and intended prompt strings are sent when generating image previews, preventing empty or unintended prompts from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->