### PR TITLE
fix: Balance face preservation with transformation - reduce IP-Adapte…

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -60,7 +60,7 @@ class RunWareService:
         width: int = 1024,
         height: int = 1024,
         steps: int = 40,
-        cfg_scale: float = 8.5
+        cfg_scale: float = 9.0
     ) -> bytes:
         """
         Generate image with face reference preservation using IP-Adapter FaceID
@@ -152,7 +152,7 @@ class RunWareService:
                     {
                         "model": "runware:105@1",  # IP-Adapter FaceID model from documentation
                         "guideImage": face_data_uri,  # Direct base64 data URI
-                        "weight": 1.0  # 🔧 FIXED: Maximum allowed by RunWare API (1.5 caused 400 error)
+                        "weight": 0.7  # 🚀 BALANCED: Face preservation with transformation (1.0 was too strong)
                     }
                 ]
             }


### PR DESCRIPTION
…r weight for spiritual avatar generation

🚀 TRANSFORMATION BALANCE FIX:
- Reduce IP-Adapter weight from 1.0 to 0.7 (balanced face preservation)
- Increase CFG Scale from 8.5 to 9.0 (stronger prompt following)

❌ BEFORE (Weight = 1.0):
- TOO STRONG face preservation
- Business suit preserved (no transformation)
- Office background preserved (no daily themes)
- Same uploaded photo returned unchanged

✅ AFTER (Weight = 0.7):
- BALANCED face preservation (same person's face)
- Body transforms (business suit → spiritual robes)
- Background transforms (office → daily theme settings)
- Daily variations work (different clothes/backgrounds per day)

🎯 EXPECTED RESULTS:
- Same face from uploaded photo (70% preservation)
- Transform to spiritual avatar with daily themes:
  * Monday: White robes + Himalayan mountains
  * Tuesday: Maroon robes + Ashram hall
  * Wednesday: Green kurta + Forest setting
  * etc.

This addresses the core issue where no transformation was happening due to overly strong face preservation.