### PR TITLE
🎯 Fix daily theme transformation: Reduce IP-Adapter weight to 0.65

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -61,7 +61,7 @@ class RunWareService:
         height: int = 1024,
         steps: int = 40,
         cfg_scale: float = 9.0,
-        ip_adapter_weight: float = 0.75
+        ip_adapter_weight: float = 0.65
     ) -> bytes:
         """
         Generate image with face reference preservation using IP-Adapter FaceID


### PR DESCRIPTION
- Changed default ip_adapter_weight from 0.75 to 0.65 in generate_with_face_reference
- This allows more clothing and background transformation while preserving face
- Should fix issue where all days showed same orange clothes/background
- Based on code analysis: 0.75 was too strong, preserving everything
- Expected result: Saturday = Gray robes + Cave, other days = correct themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the default value for a parameter affecting face reference generation to improve output results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->