### PR TITLE
🎯 FINAL FIX: Reduce IP-Adapter weight to 0.35 for maximum transformation

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -61,7 +61,7 @@ class RunWareService:
         height: int = 1024,
         steps: int = 40,
         cfg_scale: float = 9.0,
-        ip_adapter_weight: float = 0.65
+        ip_adapter_weight: float = 0.35
     ) -> bytes:
         """
         Generate image with face reference preservation using IP-Adapter FaceID


### PR DESCRIPTION
- Changed default ip_adapter_weight from 0.65 to 0.35 in generate_with_face_reference
- RunWare documentation recommends 0.3-0.4 for dramatic scene/clothing changes
- Previous weights (0.75 → 0.65) were too strong, preserving clothes/background
- Expected result: Saturday = CHARCOAL GRAY robes + Cave setting (not orange)
- Should now properly transform clothes and background while preserving face
- Based on code analysis: IP-Adapter weight was the root blocking factor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adjusted the default influence of the FaceID model in image generation, which may result in images with a more balanced use of facial reference by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->