### PR TITLE
🎯 BREAKTHROUGH FIX: Reduce CFG Scale to 4.0 for dramatic transformations

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -60,7 +60,7 @@ class RunWareService:
         width: int = 1024,
         height: int = 1024,
         steps: int = 40,
-        cfg_scale: float = 9.0,
+        cfg_scale: float = 4.0,
         ip_adapter_weight: float = 0.35
     ) -> bytes:
         """


### PR DESCRIPTION
- Changed cfg_scale from 9.0 to 4.0 in generate_with_face_reference
- HIGH CFG (9.0) was making AI stick to reference image, ignoring prompts
- LOW CFG (4.0) allows AI to follow transformation prompts aggressively
- RunWare best practice: 3.0-5.0 for dramatic changes, 7.0+ for minimal changes
- Combined with IP-Adapter weight 0.35 should now achieve full transformation
- Expected: Saturday = CHARCOAL GRAY robes + Cave (not orange office!)
- Root cause: CFG Scale was blocking all prompt-based transformations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the default configuration for image generation, which may affect the appearance of generated images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->