### PR TITLE
ULTRA-AGGRESSIVE: IP-Adapter weight 0.15 for maximum transformation (…

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -62,7 +62,7 @@ class RunWareService:
         height: int = 1024,
         steps: int = 40,
         cfg_scale: float = 4.0,
-        ip_adapter_weight: float = 0.25
+        ip_adapter_weight: float = 0.15
     ) -> bytes:
         """
         Generate image with face reference preservation using IP-Adapter FaceID


### PR DESCRIPTION
…even lower than Runway 0.25 guidance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the default setting for the IP-Adapter FaceID guidance weight during image generation, which may affect the appearance of generated images when using face reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->