### PR TITLE
BREAKTHROUGH: Switch to Image-to-Image + Strength for superior face p…

### DIFF
--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -168,7 +168,7 @@ class RunWareService:
                 "seed": random_seed,  # 🎲 FORCE NEW GENERATION: Prevents RunWare caching
             }
             
-            logger.info(f"🎯 RunWare Image-to-Image generation starting...")
+            logger.info("🎯 RunWare Image-to-Image generation starting...")
             logger.info(f"📝 Prompt: {prompt[:100]}...")
             logger.info(f"🔧 Strength: {clamped_strength} (low = preserve face, high = transform more)")
             logger.info(f"🎲 Random seed: {random_seed} (prevents caching)")


### PR DESCRIPTION
…reservation

- Replace IP-Adapter FaceID with seedImage + strength approach
- Use original Swamiji photo as seedImage (base for transformation)
- Low strength (0.15) = preserve face, transform clothes/background
- Better control: face preserved via seedImage, everything else via prompt
- Follows RunWare docs: seedImage + strength = optimal face preservation
- Expected result: Same face, dramatic daily theme transformations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated face preservation to an Image-to-Image workflow with adjustable strength for improved control over transformations.
  * Changed API interactions to use "seedImage" and "strength" instead of previous parameters.
  * Enhanced logging and documentation to describe the new face preservation method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->