### PR TITLE
CRITICAL FIX: IP-Adapter weight 0.15→0.7 for proper face preservation

### DIFF
--- a/backend/ADMIN_PRICING_GUIDE.md
+++ b/backend/ADMIN_PRICING_GUIDE.md
@@ -147,8 +147,8 @@ GET /api/admin/pricing/alerts
 - **Low demand periods**: 15-16 credits (stimulate demand)
 
 ### **Avatar Generation Approaches:**
-- **Balanced approach**: CFG 8.0 + IP-Adapter 0.4 (general avatars)
-- **Ultra-minimal approach**: CFG 12.0 + IP-Adapter 0.15 (maximum variation)
+- **Balanced approach**: CFG 15.0 + IP-Adapter 0.7 (default - strong face preservation with theme transformation)
+- **Ultra-minimal approach**: CFG 18.0 + IP-Adapter 0.15 (alternate setting for maximum variation)
 
 ## 🚨 Important Reminders
 

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -101,8 +101,8 @@ class RunWareService:
             if not self.api_key:
                 raise HTTPException(status_code=503, detail="RunWare API key not configured")
                 
-            # 🎯 FULL IMAGE APPROACH: Use complete reference image with ultra-low IP-Adapter weight
-            # Theory: Low weight (0.15) preserves only face identity, high CFG (15.0) forces prompt variation
+            # 🎯 FULL IMAGE APPROACH: Use complete reference image with balanced IP-Adapter weight
+            # Theory: Balanced weight (~0.7) preserves face identity while allowing themed transformation
             try:
                 pil_image = Image.open(io.BytesIO(face_image_bytes))
                 original_format = pil_image.format
@@ -113,10 +113,10 @@ class RunWareService:
                 pil_image = ImageOps.exif_transpose(pil_image)
                 logger.info(f"🔄 EXIF orientation applied, final size: {pil_image.size}")
                 
-                # 🎯 FULL IMAGE APPROACH: No cropping, no masking - rely on ultra-low IP-Adapter weight
-                # Theory: IP-Adapter weight 0.15 + CFG 15.0 = face preserved, body/background from prompt
-                logger.info(f"🎯 Using FULL IMAGE approach with ultra-low IP-Adapter weight")
-                logger.info(f"🎯 Theory: Low IP weight preserves face only, high CFG forces prompt variation")
+                # 🎯 FULL IMAGE APPROACH: No cropping, no masking - rely on balanced IP-Adapter weight
+                # Theory: IP-Adapter weight ~0.7 + CFG 15.0 = face preserved, body/background from prompt
+                logger.info(f"🎯 Using FULL IMAGE approach with balanced IP-Adapter weight (~0.7)")
+                logger.info(f"🎯 Theory: Balanced IP weight preserves face identity while allowing themed transformation")
                 
                 # Convert to RGB for consistent JPEG format (handles all image modes)
                 if pil_image.mode != 'RGB':
@@ -220,7 +220,7 @@ class RunWareService:
                 "ipAdapters": [{
                     "model": self.ip_adapter_model,  # 🎯 FACE-ONLY IP-ADAPTER: Configurable face preservation model
                     "guideImage": face_data_uri,  # Reference full image (no cropping/masking)
-                    "weight": clamped_weight  # 🎯 LOW WEIGHT: Preserve face identity only, not full image style
+                    "weight": clamped_weight  # 🎯 BALANCED WEIGHT: Strong face identity while allowing theme transformation
                 }]
             }
             
@@ -228,7 +228,7 @@ class RunWareService:
             logger.info(f"📝 Prompt: {prompt[:100]}...")
             logger.info(f"🔧 IP-Adapter weight: {clamped_weight} (LOW: Face identity only, not full image duplication)")
             logger.info(f"📊 CFG Scale: {clamped_cfg} (HIGH: Strong prompt guidance to override reference)")
-            logger.info("🎯 Using FULL IMAGE approach (no cropping/masking - relies on ultra-low IP weight)")
+            logger.info("🎯 Using FULL IMAGE approach (no cropping/masking - relies on balanced IP-Adapter weight)")
             logger.info(f"🎲 Random seed: {random_seed} (prevents caching)")
             logger.info(f"🔧 IP-Adapter model: {self.ip_adapter_model} (Face-only preservation model, not image mode)")
             
@@ -387,7 +387,7 @@ class RunWareService:
         ⚠️ DEPRECATED: Legacy face cropping method - NO LONGER USED
         
         This method was part of the old masking approach that caused transparency issues.
-        The current implementation uses FULL IMAGE approach with ultra-low IP-Adapter weights.
+        The current implementation uses FULL IMAGE approach with balanced IP-Adapter weight (~0.7).
         
         Kept for backwards compatibility only. Will be removed in future versions.
         
@@ -1181,10 +1181,10 @@ inconsistent lighting, poor composition, amateur photography, low resolution, pi
         """
         try:
             # REFRESH.MD: FIX - Get both the image and the actual prompt used.
-            # PHASE 2: Using IP-Adapter FULL IMAGE approach with ultra-low weight
+            # PHASE 2: Using IP-Adapter FULL IMAGE approach with balanced weight (~0.7)
             generated_image_bytes, final_prompt = await self.generate_themed_image_bytes(
                 custom_prompt=custom_prompt
-                # Using full image + low IP weight for face preservation without masking artifacts
+                # Using full image + balanced IP weight for face preservation without masking artifacts
             )
 
             unique_filename = f"swamiji_masked_theme_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4()}.png"

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -40,15 +40,15 @@ class RunWareService:
     🎯 RunWare API Service for IP-Adapter FULL IMAGE face preservation
     Achieves 80-90% face consistency with $0.0006 per image cost
     
-    This service uses RunWare's IP-Adapter with COMPLETE reference images and ultra-low weights
+    This service uses RunWare's IP-Adapter with COMPLETE reference images and proper weights
     to preserve face identity while allowing AI to create new body poses, backgrounds, and clothing from prompts.
-    The full-image approach with low IP-Adapter weight provides maximum creative freedom without masking artifacts.
+    The full-image approach with balanced IP-Adapter weight provides strong face preservation with theme transformation.
     """
     
     # 🔧 CONFIGURATION CONSTANTS: FIXED BASED ON USER ANALYSIS
     # Problem: IP-Adapter was duplicating entire reference image instead of just face
     BALANCED_CFG_SCALE = 15.0  # 🎯 HIGH PROMPT GUIDANCE: Force prompt to override reference image
-    BALANCED_IP_ADAPTER_WEIGHT = 0.15  # 🎯 LOW FACE INFLUENCE: Preserve only face identity, not full image
+    BALANCED_IP_ADAPTER_WEIGHT = 0.7   # 🎯 PROPER FACE PRESERVATION: Strong face identity while allowing theme transformation
     
     ULTRA_MINIMAL_CFG_SCALE = 18.0  # 🔥 MAXIMUM PROMPT GUIDANCE: Complete prompt dominance
     ULTRA_MINIMAL_IP_ADAPTER_WEIGHT = 0.05  # 🔥 MINIMAL FACE INFLUENCE: Only basic face structure
@@ -78,9 +78,9 @@ class RunWareService:
         Generate image with face preservation using FULL IMAGE approach based on user analysis
         
         PROBLEM FIXED: IP-Adapter was duplicating entire reference image instead of just face
-        SOLUTION: Full image + ultra-low IP weight + high CFG + strong negatives (NO cropping/masking)
+        SOLUTION: Full image + proper IP weight + high CFG + strong negatives (NO cropping/masking)
         
-        Uses COMPLETE reference image + ultra-low IP-Adapter weight (0.15) + high CFG scale (15.0)
+        Uses COMPLETE reference image + proper IP-Adapter weight (0.7) + high CFG scale (15.0)
         + strong reference-blocking negatives to preserve ONLY facial identity while forcing AI to generate
         completely new body poses, clothing, and backgrounds from prompts. No transparency issues.
         


### PR DESCRIPTION
- Fix BALANCED_IP_ADAPTER_WEIGHT: 0.15 → 0.7
- Now preserves Swamiji face while transforming themes
- Daily themes will work with proper face preservation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Improvements
  * Increased default IP-Adapter influence for face-reference generation to a balanced setting, producing stronger facial preservation in full-image workflows without manual tuning.

* Documentation
  * Reworded guidance from “ultra-low” to “balanced” weights and updated recommended setting to ~0.7; pricing/approach guide reflects the new defaults and clarifies trade-offs between preservation and variation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->