### PR TITLE
fix(api): add prefix to lora router to fix 404 error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -504,7 +504,7 @@ app.include_router(admin_integrations.router)
 # CORE.MD: Group all marketing-related routers together for clarity.
 app.include_router(social_marketing_router)
 print("✅ Social media marketing router registered")
-app.include_router(lora_router) # LoRA Model Management
+app.include_router(lora_router, prefix="/api/admin/lora", tags=["Lora Management"])
 print("✅ LoRA management router registered.")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LoRA management endpoints are now accessible under the unified path prefix: /api/admin/lora.
  * Existing LoRA routes are preserved under the new namespace; update any integrations to use the new paths.

* **Documentation**
  * API documentation groups LoRA endpoints under the “Lora Management” tag for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->