### PR TITLE
fix(frontend): send owner field in createLoraModel API call

### DIFF
--- a/frontend/src/components/admin/LoraTrainingCenter.jsx
+++ b/frontend/src/components/admin/LoraTrainingCenter.jsx
@@ -37,7 +37,7 @@ const LoraTrainingCenter = () => {
     setError(null);
     setSuccess(null);
     try {
-      const response = await enhanced_api.createLoraModel();
+      const response = await enhanced_api.createLoraModel({ owner: 'voicebootix' });
       if (response?.success) {
         setModelData(response.data);
         setSuccess(response.message);

--- a/frontend/src/services/enhanced-api.js
+++ b/frontend/src/services/enhanced-api.js
@@ -304,8 +304,8 @@ class EnhancedAPI {
   }
 
   // Lora Training API Methods
-  async createLoraModel() {
-    return this.post('/api/admin/lora/create-model', {});
+  async createLoraModel(data) {
+    return this.post('/api/admin/lora/create-model', data);
   }
 
   // Agent Chat


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LoRA model creation now includes owner attribution, ensuring models are created under the correct account. Success/error handling and the training flow remain unchanged.

* **Chores**
  * Updated service integration to send a payload when creating models for better alignment with the API. No visible UI changes; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->