### PR TITLE
feat(lora): implement new url-based training flow

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -509,10 +509,10 @@ async def generate_image_preview(
         if base_image_bytes:
             try:
                 base_hash_full = hashlib.sha256(base_image_bytes).hexdigest()
-                base_hash_short = base_hash_full[:16]
-                image_diff = "different" if generated_hash_full != base_hash_full else "same"
+                        base_hash_short = base_hash_full[:16]
+                        image_diff = "different" if generated_hash_full != base_hash_full else "same"
                 logger.info(f"Image diff check successful. Base hash: {base_hash_short}, Generated hash: {generated_hash_short}")
-            except Exception as diff_err:
+        except Exception as diff_err:
                 logger.warning(f"Could not compute base image hash for diff check: {diff_err}")
         
         # 🛡️ ENHANCED HTTP header sanitization - CORE.MD: Fix emoji encoding errors

--- a/frontend/src/components/admin/LoraTrainingCenter.jsx
+++ b/frontend/src/components/admin/LoraTrainingCenter.jsx
@@ -42,8 +42,21 @@ const LoraTrainingCenter = () => {
       setError("Model must be created first (Step 1).");
       return;
     }
-    if (!trainingDataUrl) {
+
+    const trimmedUrl = trainingDataUrl.trim();
+    if (!trimmedUrl) {
       setError("Please provide a public URL for the training data ZIP file.");
+      return;
+    }
+
+    try {
+      const url = new URL(trimmedUrl);
+      if (url.protocol !== 'https:' || !url.pathname.toLowerCase().endsWith('.zip')) {
+        setError("Invalid URL. Please provide a public HTTPS URL that points directly to a .zip file.");
+        return;
+      }
+    } catch (e) {
+      setError("Invalid URL format. Please enter a full and valid URL (e.g., https://...).");
       return;
     }
     
@@ -56,7 +69,7 @@ const LoraTrainingCenter = () => {
       const payload = {
         model_owner: modelData.owner,
         model_name: modelData.name,
-        training_data_url: trainingDataUrl
+        training_data_url: trimmedUrl
       };
 
       const response = await enhanced_api.startTrainingJob(payload);

--- a/frontend/src/components/admin/LoraTrainingCenter.jsx
+++ b/frontend/src/components/admin/LoraTrainingCenter.jsx
@@ -162,8 +162,8 @@ const LoraTrainingCenter = () => {
           <p className="text-sm text-gray-600 mt-2">
             View your training progress on Replicate:
           </p>
-          <a href={`https://replicate.com/trainings/${trainingJob.id}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">
-            {`https://replicate.com/trainings/${trainingJob.id}`}
+          <a href={`https://replicate.com/p/${trainingJob.id}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">
+            {`https://replicate.com/p/${trainingJob.id}`}
           </a>
           <pre className="text-xs bg-gray-900 text-white p-3 rounded-md mt-2 overflow-x-auto">
             {JSON.stringify(trainingJob, null, 2)}

--- a/frontend/src/components/admin/LoraTrainingCenter.jsx
+++ b/frontend/src/components/admin/LoraTrainingCenter.jsx
@@ -5,7 +5,8 @@ import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Upload, Rocket, CheckCircle, XCircle, Loader2, BrainCircuit } from 'lucide-react';
 import enhanced_api from '@/services/enhanced-api'; // Corrected: removed curly braces for default import
-import { useDropzone } from 'react-dropzone';
+// Dropzone is no longer needed with the new URL-based flow
+// import { useDropzone } from 'react-dropzone';
 
 const LoraTrainingCenter = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -13,59 +14,9 @@ const LoraTrainingCenter = () => {
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(null);
   const [modelData, setModelData] = useState(null);
-  const [zipFile, setZipFile] = useState(null);
-  const [zipUploadUrl, setZipUploadUrl] = useState(null);
-  const [uploadProgress, setUploadProgress] = useState(0);
+  const [trainingDataUrl, setTrainingDataUrl] = useState(''); // State for the public URL
   const [trainingJob, setTrainingJob] = useState(null);
-  const xhrRef = useRef(null);
-
-  useEffect(() => {
-    // Cleanup function to abort XHR request if component unmounts
-    return () => {
-      if (xhrRef.current && xhrRef.current.readyState !== 4) {
-        try {
-          xhrRef.current.abort();
-        } catch (e) {
-          console.error("Error aborting XHR request on unmount:", e);
-        }
-      }
-    };
-  }, []);
-
-  const onDrop = useCallback((acceptedFiles, fileRejections) => {
-    setError(null);
-
-    // Handle rejected files first for specific feedback
-    if (fileRejections.length > 0) {
-        const rejection = fileRejections[0];
-        const errorMessage = rejection.errors.map(e => e.message).join(', ');
-        setError(`File rejected: ${errorMessage}. Please upload a valid ZIP file named 'swamiji_training_data.zip'.`);
-        setZipFile(null);
-        return;
-    }
-
-    // Handle accepted files
-    if (acceptedFiles.length > 0) {
-        const file = acceptedFiles[0];
-        if (file && file.name === 'swamiji_training_data.zip') {
-            setZipFile(file);
-        } else {
-            setZipFile(null);
-            setError(`Invalid filename. The file must be named "swamiji_training_data.zip". You provided: "${file.name}"`);
-        }
-    }
-  }, []);
-
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
-    onDrop,
-    multiple: false,
-    disabled: !modelData || isLoading,
-    accept: {
-      'application/zip': ['.zip'],
-      'application/x-zip-compressed': ['.zip'],
-    }
-  });
-
+  
   const handleCreateModel = async () => {
     setIsLoading(true);
     setLoadingMessage('Step 1: Creating model placeholder on Replicate...');
@@ -85,96 +36,40 @@ const LoraTrainingCenter = () => {
     setIsLoading(false);
     setLoadingMessage('');
   };
-
-  const handleUploadZip = async () => {
+  
+  const handleStartTraining = async () => {
     if (!modelData) {
       setError("Model must be created first (Step 1).");
       return;
     }
-    if (!zipFile) {
-      setError("Please select the 'swamiji_training_data.zip' file first.");
-      return;
-    }
-
-    setIsLoading(true);
-    setLoadingMessage('Step 2.1: Requesting secure upload URL from Replicate...');
-    setError(null);
-    setSuccess(null);
-
-    try {
-      // Get the signed URL from our backend
-      const prepResponse = await enhanced_api.prepareTrainingUpload();
-      if (!prepResponse?.success || !prepResponse.data?.upload_url || !prepResponse.data?.serving_url) {
-        throw new Error(prepResponse?.message || 'Failed to get upload or serving URL.');
-      }
-
-      const { upload_url, serving_url } = prepResponse.data;
-      setLoadingMessage('Step 2.2: Uploading ZIP file directly to Replicate...');
-      
-      // Use XMLHttpRequest to upload directly to the signed URL and track progress
-      const xhr = new XMLHttpRequest();
-      xhrRef.current = xhr; // Store XHR instance in ref
-      
-      xhr.open('PUT', upload_url, true);
-      xhr.setRequestHeader('Content-Type', 'application/zip');
-      
-      xhr.upload.onprogress = (event) => {
-        if (event.lengthComputable) {
-          const percentComplete = Math.round((event.loaded / event.total) * 100);
-          setUploadProgress(percentComplete);
-        }
-      };
-
-      xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          setZipUploadUrl(serving_url);
-          setSuccess('ZIP file uploaded to Replicate successfully!');
-          setLoadingMessage('');
-        } else {
-          setError(`Upload failed. Status: ${xhr.status} ${xhr.statusText}`);
-          setLoadingMessage('');
-        }
-        setIsLoading(false);
-        setUploadProgress(0);
-        xhrRef.current = null;
-      };
-
-      xhr.onerror = () => {
-        setError('Network error during file upload.');
-        setIsLoading(false);
-        setUploadProgress(0);
-        xhrRef.current = null;
-      };
-
-      xhr.send(zipFile);
-
-    } catch (e) {
-      setError(e.message || 'A client-side error occurred during upload preparation.');
-      setIsLoading(false);
-      setLoadingMessage('');
-    }
-  };
-  
-  const handleStartTraining = async () => {
-    if (!zipUploadUrl || !modelData) {
-      setError("ZIP file must be uploaded and model must be created first.");
+    if (!trainingDataUrl) {
+      setError("Please provide a public URL for the training data ZIP file.");
       return;
     }
     
     setIsLoading(true);
-    setLoadingMessage("Step 3.1: Starting the training job on Replicate...");
+    setLoadingMessage("Starting the training job on Replicate...");
     setError(null);
     setSuccess(null);
 
     try {
-      // TODO: Actually call the enhanced_api method to start the training job
-      // This will involve passing modelData and zipUploadUrl to the backend
-      console.log("Starting training with:", { model: modelData, zipUrl: zipUploadUrl });
-      await new Promise(resolve => setTimeout(resolve, 2000)); // Placeholder for API call
-      setSuccess("Training job started successfully! Check Replicate for progress.");
+      const payload = {
+        model_owner: modelData.owner,
+        model_name: modelData.name,
+        training_data_url: trainingDataUrl
+      };
+
+      const response = await enhanced_api.startTrainingJob(payload);
+      
+      if (response?.success) {
+        setTrainingJob(response.data);
+        setSuccess(`Training job started successfully! Job ID: ${response.data.id}`);
+      } else {
+        throw new Error(response?.message || "Failed to start training job.");
+      }
 
     } catch (e) {
-      setError(e.message || "Failed to start training job.");
+      setError(e.message || "An error occurred while starting the training job.");
     } finally {
       setIsLoading(false);
       setLoadingMessage("");
@@ -221,44 +116,47 @@ const LoraTrainingCenter = () => {
         {modelData && <pre className="mt-2 text-xs bg-gray-100 p-2 rounded">{JSON.stringify(modelData, null, 2)}</pre>}
       </div>
 
-      {/* Step 2: Upload ZIP */}
+      {/* Step 2: Provide Training Data URL */}
       <div className={`border rounded-lg p-4 ${!modelData && 'opacity-50'}`}>
-        <h4 className="font-semibold">Step 2: Upload `swamiji_training_data.zip`</h4>
+        <h4 className="font-semibold">Step 2: Provide Training Data URL</h4>
         <p className="text-sm text-gray-500 mt-1">
-            Upload the ZIP file containing 10-15 training images.
+          Upload your `swamiji_training_data.zip` to a public host (like Google Drive or S3) and paste the direct download URL below.
         </p>
-        <div {...getRootProps()} className={`mt-3 border-2 border-dashed rounded-lg p-8 text-center cursor-pointer ${isDragActive ? 'border-purple-500 bg-purple-50' : 'border-gray-300'}`}>
-            <input {...getInputProps()} disabled={!modelData || isLoading} />
-            <Upload className="mx-auto h-10 w-10 text-gray-400" />
-            {zipFile ? (
-                <p className="mt-2 text-green-600">{zipFile.name} selected.</p>
-            ) : (
-                <p className="mt-2 text-sm text-gray-500">Drag 'n' drop 'swamiji_training_data.zip' here, or click to select.</p>
-            )}
-        </div>
-        {zipFile && !zipUploadUrl && (
-            <Button onClick={handleUploadZip} disabled={isLoading} className="mt-3">
-                <Upload className="mr-2" /> Upload ZIP to Replicate
-            </Button>
-        )}
-        {isLoading && uploadProgress > 0 && (
-            <div className="w-full bg-gray-200 rounded-full h-2.5 mt-3">
-                <div className="bg-purple-600 h-2.5 rounded-full" style={{ width: `${uploadProgress}%` }}></div>
-            </div>
-        )}
+        <Input
+          type="url"
+          placeholder="https://example.com/path/to/swamiji_training_data.zip"
+          value={trainingDataUrl}
+          onChange={(e) => setTrainingDataUrl(e.target.value)}
+          disabled={!modelData || isLoading}
+          className="mt-3"
+        />
       </div>
       
-       {/* Step 3: Start Training */}
-      <div className={`border rounded-lg p-4 ${!zipUploadUrl && 'opacity-50'}`}>
+      {/* Step 3: Start Training */}
+      <div className={`border rounded-lg p-4 ${!trainingDataUrl && 'opacity-50'}`}>
         <h4 className="font-semibold">Step 3: Start Training</h4>
         <p className="text-sm text-gray-500 mt-1">
             This will start the LoRA training job on Replicate. It can take 15-30 minutes.
         </p>
-         <Button onClick={handleStartTraining} disabled={!zipUploadUrl || isLoading} className="mt-3">
+         <Button onClick={handleStartTraining} disabled={!trainingDataUrl || isLoading} className="mt-3">
             <Rocket className="mr-2" /> Start Training Job
         </Button>
       </div>
 
+      {trainingJob && (
+        <div className="border rounded-lg p-4 mt-4 bg-gray-50">
+          <h4 className="font-semibold text-green-700">Training Job Details</h4>
+          <p className="text-sm text-gray-600 mt-2">
+            View your training progress on Replicate:
+          </p>
+          <a href={`https://replicate.com/trainings/${trainingJob.id}`} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">
+            {`https://replicate.com/trainings/${trainingJob.id}`}
+          </a>
+          <pre className="text-xs bg-gray-900 text-white p-3 rounded-md mt-2 overflow-x-auto">
+            {JSON.stringify(trainingJob, null, 2)}
+          </pre>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/services/enhanced-api.js
+++ b/frontend/src/services/enhanced-api.js
@@ -308,6 +308,10 @@ class EnhancedAPI {
     return this.post('/api/admin/lora/create-model', data);
   }
 
+  async startTrainingJob(data) {
+    return this.post('/api/admin/lora/start-training', data);
+  }
+
   async prepareTrainingUpload() {
     return this.post('/api/admin/lora/prepare-training-upload', {});
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Start LoRA training directly by providing a public training-data URL.
  - Show training job details after initiation, including job ID, link to the training page, and raw training response.

- Refactor
  - Replaced ZIP drag-and-drop upload with a URL-based flow; removed upload progress and related UI.
  - Backend now starts training via a single start-training endpoint with stricter URL typing and updated error messaging.

- Tests
  - None.

- Chores
  - Minor UI text and structural updates to reflect the new flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->