### PR TITLE
fix(core): remove import for deleted lora_router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -89,7 +89,6 @@ from routers import auth, user, spiritual, sessions, followup, donations, credit
 from routers import admin_products, admin_subscriptions, admin_credits, admin_analytics, admin_content, admin_settings
 from routers import admin_overview, admin_integrations
 from routers import content, ai, community, session_analytics
-from routers.lora_management_router import lora_router # LoRA Model Management
 import db
 
 # Import the migration runner


### PR DESCRIPTION
Removes the import statement for the now-deleted lora_management_router.py to prevent a ModuleNotFoundError during application startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deactivated LoRA model management functionality at application startup.
  * Related LoRA management endpoints are no longer registered or accessible to users.
  * Users relying on these endpoints will experience unavailable routes and should adjust workflows accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->