### PR TITLE
fix(services): use absolute imports to prevent deployment errors

### DIFF
--- a/backend/services/replicate_service.py
+++ b/backend/services/replicate_service.py
@@ -3,7 +3,7 @@ import httpx
 from typing import Optional, Dict, Any, List
 import asyncio
 
-from ..config.logging_config import get_logger
+from backend.config.logging_config import get_logger
 
 logger = get_logger(__name__)
 

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -1,9 +1,9 @@
 import os
 from typing import Optional
 
-from ..config.logging_config import get_logger
-from ..services.replicate_service import ReplicateService, get_replicate_service
-from ..services.supabase_storage_service import SupabaseStorageService, get_storage_service
+from backend.config.logging_config import get_logger
+from backend.services.replicate_service import ReplicateService, get_replicate_service
+from backend.services.supabase_storage_service import SupabaseStorageService, get_storage_service
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
Changed relative imports (e.g., '..config') to absolute imports (e.g., 'backend.config') in replicate_service.py and theme_service.py. This resolves potential ModuleNotFoundErrors on Render.