### PR TITLE
fix(service): remove unused db_pool dependency from ThemeService

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -40,14 +40,7 @@ except ImportError:
     def get_avatar_engine():
         raise HTTPException(status_code=501, detail="Avatar Generation Engine is not available.")
 
-try:
-    from services.theme_service import ThemeService, get_theme_service
-    THEME_SERVICE_AVAILABLE = True
-except ImportError:
-    THEME_SERVICE_AVAILABLE = False
-    class ThemeService: pass
-    def get_theme_service():
-        raise HTTPException(status_code=501, detail="Theme service is not available.")
+from backend.services.theme_service import ThemeService, get_theme_service
 
 try:
     from services.supabase_storage_service import SupabaseStorageService, get_storage_service

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -19,11 +19,9 @@ class ThemeService:
 
     def __init__(
         self,
-        db_pool,
         storage_service: SupabaseStorageService,
         replicate_service: ReplicateService,
     ):
-        self.db_pool = db_pool
         self.storage_service = storage_service
         self.replicate_service = replicate_service
 
@@ -89,10 +87,9 @@ class ThemeService:
         )
 
 
-def get_theme_service(db_pool) -> ThemeService:
+def get_theme_service() -> ThemeService:
     """Dependency injector for ThemeService."""
     return ThemeService(
-        db_pool=db_pool,
         storage_service=get_storage_service(),
         replicate_service=get_replicate_service(),
     )


### PR DESCRIPTION
Removed the db_pool parameter from ThemeService's constructor and its dependency injector. The service no longer interacts with the database, and this unused dependency was causing injection failures and a 501 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified theme service setup by removing an unnecessary dependency, reducing setup complexity.
* **Behavior Change**
  * The app now requires the theme service at startup; if that service is absent the application will fail to start rather than returning a runtime 501 error.
* **No Functional Change**
  * Image generation and user-facing behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->