### PR TITLE
fix(imports): revert to relative imports for Render compatibility

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -40,7 +40,7 @@ except ImportError:
     def get_avatar_engine():
         raise HTTPException(status_code=501, detail="Avatar Generation Engine is not available.")
 
-from backend.services.theme_service import ThemeService, get_theme_service
+from services.theme_service import ThemeService, get_theme_service
 
 try:
     from services.supabase_storage_service import SupabaseStorageService, get_storage_service

--- a/backend/services/replicate_service.py
+++ b/backend/services/replicate_service.py
@@ -3,7 +3,7 @@ import httpx
 from typing import Optional, Dict, Any, List
 import asyncio
 
-from backend.config.logging_config import get_logger
+from ..config.logging_config import get_logger
 
 logger = get_logger(__name__)
 

--- a/backend/services/theme_service.py
+++ b/backend/services/theme_service.py
@@ -1,9 +1,9 @@
 import os
 from typing import Optional
 
-from backend.config.logging_config import get_logger
-from backend.services.replicate_service import ReplicateService, get_replicate_service
-from backend.services.supabase_storage_service import SupabaseStorageService, get_storage_service
+from ..config.logging_config import get_logger
+from ..services.replicate_service import ReplicateService, get_replicate_service
+from ..services.supabase_storage_service import SupabaseStorageService, get_storage_service
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
Changed absolute imports ('from backend...') back to relative imports ('from ..') in the router and services. This fixes the 'ModuleNotFoundError: No module named 'backend'' that occurs when running the app inside the 'backend' directory on Render.