### PR TITLE
refactor(upload): Switch to Base64 upload to fix content-type issues

### DIFF
--- a/backend/routers/social_media_marketing_router.py
+++ b/backend/routers/social_media_marketing_router.py
@@ -16,6 +16,7 @@ import json
 from datetime import datetime, timedelta, date
 import asyncio
 import base64 # Added for base64 encoding of image bytes
+import binascii # Added for base64 decoding errors
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Response, Request
 from pydantic import BaseModel, Field
@@ -244,11 +245,32 @@ async def upload_preview_image(
 ):
     """
     Uploads a Base64 encoded preview image to storage and returns the public URL.
+    Handles potential double-encoding and validates payload.
     """
     try:
-        image_data = base64.b64decode(request.image_base64)
+        # Pre-flight size check to prevent decoding massive payloads
+        # Estimate decoded size: floor(len(s) * 3 / 4) - padding
+        padding = request.image_base64.count('=')
+        decoded_size_estimate = (len(request.image_base64) * 3 // 4) - padding
+        if decoded_size_estimate > MAX_FILE_SIZE:
+            raise HTTPException(status_code=400, detail="Estimated payload size exceeds limit.")
+
+        image_data = None
+        try:
+            image_data = base64.b64decode(request.image_base64, validate=True)
+        except (ValueError, binascii.Error):
+            raise HTTPException(status_code=400, detail="Invalid base64 payload.")
+
+        # Detect and handle common double-encoding case (result is still base64 text)
+        try:
+            if image_data.isascii() and all(c in b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=' for c in image_data):
+                logger.warning("Potential double-encoding detected. Attempting second decode.")
+                image_data = base64.b64decode(image_data, validate=True)
+        except (ValueError, binascii.Error):
+            raise HTTPException(status_code=400, detail="Invalid double-encoded base64 payload.")
+        
         if len(image_data) > MAX_FILE_SIZE:
-            raise HTTPException(status_code=400, detail="Preview file size exceeds limit.")
+            raise HTTPException(status_code=400, detail="Final payload size exceeds limit.")
 
         unique_filename = f"preview_{uuid.uuid4()}.png"
         file_path_in_bucket = f"previews/{unique_filename}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Preview image uploads now use a Base64 JSON payload instead of multipart/form-data.
  - File size is validated before upload; uploads use a standardized preview filename pattern.
  - Frontend preserves the existing preview-return structure (preview URL) so downstream flows are unchanged.
  - Improved and clearer browser console/error messages during upload failures.
  - No UI changes; generating and displaying preview URLs behaves the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->