### PR TITLE
fix: Add missing wrapper functions to jwt_config.py

### DIFF
--- a/backend/auth/jwt_config.py
+++ b/backend/auth/jwt_config.py
@@ -138,3 +138,16 @@ class JWTHandler:
             "role": JWTHandler.get_user_role_from_token(request),
             "payload": payload
         }
+
+# Standalone wrapper functions for backwards compatibility
+def get_user_email_from_token(request: Request) -> Optional[str]:
+    """Standalone wrapper for JWTHandler.get_user_email_from_token"""
+    return JWTHandler.get_user_email_from_token(request)
+
+def get_user_id_from_token(request: Request) -> str:
+    """Standalone wrapper for JWTHandler.get_user_id_from_token"""
+    return JWTHandler.get_user_id_from_token(request)
+
+def get_user_role_from_token(request: Request) -> str:
+    """Standalone wrapper for JWTHandler.get_user_role_from_token"""
+    return JWTHandler.get_user_role_from_token(request)


### PR DESCRIPTION
- Added standalone get_user_email_from_token wrapper function
- Added get_user_id_from_token and get_user_role_from_token wrappers
- Fixes deployment error: ImportError cannot import name get_user_email_from_token
- Maintains backwards compatibility for existing imports
- Resolves user.py line 489 import issue