### PR TITLE
fix: initialize RAG Knowledge Engine during application startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -268,6 +268,22 @@ async def lifespan(app: FastAPI):
         print("✅ Database connection pool initialized successfully!")
         print("📊 Pool configuration: connections ready for use")
         
+        # Initialize RAG Knowledge Engine System
+        try:
+            from backend.enhanced_rag_knowledge_engine import initialize_rag_system
+            openai_api_key = os.getenv("OPENAI_API_KEY")
+            if openai_api_key:
+                await initialize_rag_system(db_pool, openai_api_key)
+                print("✅ RAG Knowledge Engine initialized successfully!")
+                print("🧠 Dynamic spiritual content generation enabled")
+            else:
+                print("⚠️ OpenAI API key not found - RAG system disabled")
+                print("   → Spiritual content will use fallback themes")
+        except Exception as rag_error:
+            print(f"⚠️ Failed to initialize RAG system: {rag_error}")
+            print("   → Will fallback to hardcoded spiritual themes")
+            print("   → App will continue normally with reduced functionality")
+        
         # Initialize monitoring system if available - Enhanced error handling
         if MONITORING_AVAILABLE:
             try:


### PR DESCRIPTION
- Added RAG system initialization to main.py startup sequence after database init
- Check for OPENAI_API_KEY environment variable before initialization
- Graceful error handling if RAG system fails to initialize
- Fallback to hardcoded spiritual themes if RAG unavailable
- This fixes the 'RAG system import failed' errors in spiritual calendar service
- Dynamic spiritual content generation now properly enabled on startup