### PR TITLE
fix: resolve deployment import error in deps.py - change relative to …

### DIFF
--- a/backend/deps.py
+++ b/backend/deps.py
@@ -1,8 +1,8 @@
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Dict, Any
-from .auth.jwt_config import JWTHandler
-from .auth.auth_helpers import AuthenticationHelper
+from auth.jwt_config import JWTHandler
+from auth.auth_helpers import AuthenticationHelper
 from datetime import datetime, timezone
 import os
 


### PR DESCRIPTION
…absolute imports

- Fixed ImportError: attempted relative import with no known parent package
- Changed 'from .auth.jwt_config' to 'from auth.jwt_config' in deps.py
- Changed 'from .auth.auth_helpers' to 'from auth.auth_helpers' in deps.py
- Absolute imports work when running 'uvicorn main:app' from backend directory
- This fixes the deployment crash that was preventing app startup
- Critical hotfix for production deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module imports to standardized absolute paths, improving consistency across environments and simplifying maintenance. This helps prevent path resolution issues during deployment and testing. No changes to application behavior, performance, or APIs are expected.
* **Chores**
  * Performed minor backend housekeeping to align with project conventions and ensure smoother integration with existing components and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->