### PR TITLE
fix: Correct db_pool logic in knowledge seeding

### DIFF
--- a/backend/knowledge_seeding_system.py
+++ b/backend/knowledge_seeding_system.py
@@ -747,10 +747,10 @@ async def run_knowledge_seeding(db_pool_override: Optional[Any] = None):
                 from . import db
             except ImportError:
                 import db
-        
-        db_pool = db.get_db_pool()
-        if db_pool is None:
-            raise Exception("Shared database pool not available - ensure main.py has initialized it")
+            
+            db_pool = db.get_db_pool()
+            if db_pool is None:
+                raise Exception("Shared database pool not available - ensure main.py has initialized it")
         
         # Get OpenAI API key
         openai_api_key = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
- Only call db.get_db_pool() when no override is provided
- Fix 'cannot access local variable db' error
- Ensure proper conditional logic for database pool handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of the database pool during knowledge seeding when no override is provided, preserving existing behavior and error messages.
* **Chores**
  * Minor formatting and indentation cleanup to improve readability.
* **Notes**
  * No user-facing changes or public API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->