### PR TITLE
fix: Resolve indentation errors preventing knowledge seeding deployment

### DIFF
--- a/backend/knowledge_seeding_system.py
+++ b/backend/knowledge_seeding_system.py
@@ -96,10 +96,10 @@ def format_embedding_for_storage(embedding, vector_support: bool = True) -> any:
                 except (ValueError, TypeError) as e:
                     logger.warning(f"🕉️ Cannot convert spiritual knowledge embedding list elements to float: {e}, using default")
                     return [0.0] * DEFAULT_EMBED_DIM
-        else:
+            else:
                 logger.warning("🕉️ Invalid spiritual knowledge embedding list, using default")
                 return [0.0] * DEFAULT_EMBED_DIM
-            else:
+        else:
             # For other types, create default vector
             logger.warning("🕉️ Unknown spiritual knowledge embedding type, using default")
             return [0.0] * DEFAULT_EMBED_DIM
@@ -811,7 +811,7 @@ async def run_knowledge_seeding(db_pool_override: Optional[Any] = None):
             try:
                 from . import db
             except ImportError:
-        import db
+                import db
         
         db_pool = db.get_db_pool()
         if db_pool is None:
@@ -863,7 +863,7 @@ async def run_knowledge_seeding(db_pool_override: Optional[Any] = None):
             await seeder.seed_complete_with_global_knowledge()
         elif effective_mode == "traditional":
             logger.info("🕉️ Running TRADITIONAL SPIRITUAL seeding only...")
-        await seeder.seed_complete_knowledge_base()
+            await seeder.seed_complete_knowledge_base()
         else:
             # This should never happen due to validation above, but safety check
             logger.error(f"❌ Unexpected effective mode: {effective_mode}")


### PR DESCRIPTION
- Fix multiple indentation issues in format_embedding_for_storage function
- Fix missing indentation in import fallback block
- Fix misaligned if-elif-else chain in seeding mode selection
- Ensure proper code structure for Python syntax compliance
- This resolves the deployment error: 'unindent does not match any outer indentation level'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected knowledge seeding flow so full seeding only runs in traditional mode.
  * Improved handling of invalid or unrecognized embeddings to consistently fall back to safe defaults.
  * Fixed fallback import behavior to run only when needed, preventing startup issues.

* **Stability**
  * Adjusted control flow to ensure predictable runtime behavior during seeding and embedding processing, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->