### PR TITLE
fix: Implement robust import for knowledge seeding

### DIFF
--- a/backend/auto_deploy_migration.py
+++ b/backend/auto_deploy_migration.py
@@ -12,15 +12,15 @@ import asyncpg
 import logging
 from pathlib import Path
 
+# Add backend directory to Python path for robust imports
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 # Try robust import for knowledge seeding
 try:
-    from .knowledge_seeding_system import run_knowledge_seeding
-except ImportError:
-    try:
-        from knowledge_seeding_system import run_knowledge_seeding
-    except ImportError:
-        run_knowledge_seeding = None
-        logging.warning("⚠️ Could not import run_knowledge_seeding. Seeding will be skipped.")
+    from knowledge_seeding_system import run_knowledge_seeding
+except ImportError as e:
+    logging.warning(f"⚠️ Could not import run_knowledge_seeding: {e}. Seeding will be skipped.")
+    run_knowledge_seeding = None
 
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
- Add backend directory to Python path for reliable module discovery
- Fix 'Could not import run_knowledge_seeding' error during deployment
- Ensure knowledge seeding is no longer skipped due to import issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Prevents failures when the optional knowledge seeding module is unavailable; the system now continues running and skips seeding.

- Improvements
  - More informative warning messages in logs when knowledge seeding cannot be loaded.

- Refactor
  - Simplified internal import logic to reduce fragility and improve startup resilience.

- Chores
  - Adjusted environment setup to ensure reliable module resolution at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->