### PR TITLE
fix: Resolve twilio dependency conflict

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -33,7 +33,7 @@ fastapi-users==13.0.0
 slowapi==0.1.9
 celery==5.4.0
 prometheus-client==0.20.0
-twilio==9.1.2
+twilio
 firebase-admin==6.5.0
 facebook-sdk==3.1.0
 requests-oauthlib==2.0.0


### PR DESCRIPTION
- Remove version pin for twilio to resolve 'No matching distribution' error
- Allow pip to install the latest stable version of twilio
- This unblocks the deployment process