### PR TITLE
fix: Resolve limits dependency conflict

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,7 +44,7 @@ scikit-learn==1.5.0
 jinja2==3.1.4
 pydantic-settings==2.3.1
 email-validator==2.2.0
-limits==3.11.1
+limits
 sqlparse==0.5.0
 supabase==2.4.2
 


### PR DESCRIPTION
- Remove version pin for limits to resolve 'No matching distribution' error
- Allow pip to install the latest stable version of limits
- This unblocks the deployment process