### PR TITLE
🌍 Enable Global Knowledge Collection - Add ENABLE_GLOBAL_KNOWLEDGE an…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -51,7 +51,7 @@ services:
         sync: false  # Set this in Render dashboard for security
       - key: PROKERALA_CLIENT_SECRET
         sync: false  # Set this in Render dashboard for security
-      # 🌍 Global Knowledge Collection Configuration  
+      # 🌍 Global Knowledge Collection Configuration
       - key: ENABLE_GLOBAL_KNOWLEDGE
         value: "true"  # Enable real-time global knowledge collection
       - key: KNOWLEDGE_SEEDING_MODE

--- a/render.yaml
+++ b/render.yaml
@@ -51,6 +51,11 @@ services:
         sync: false  # Set this in Render dashboard for security
       - key: PROKERALA_CLIENT_SECRET
         sync: false  # Set this in Render dashboard for security
+      # 🌍 Global Knowledge Collection Configuration  
+      - key: ENABLE_GLOBAL_KNOWLEDGE
+        value: "true"  # Enable real-time global knowledge collection
+      - key: KNOWLEDGE_SEEDING_MODE
+        value: "complete"  # traditional + global combined (traditional/global/complete)
       # Environment Configuration
       - key: APP_ENV
         value: "production"


### PR DESCRIPTION
…d KNOWLEDGE_SEEDING_MODE env vars

- Added ENABLE_GLOBAL_KNOWLEDGE=true for real-time global knowledge collection
- Added KNOWLEDGE_SEEDING_MODE=complete for traditional + global combined mode
- This will collect ~60-80 daily articles from CNN, BBC, Reuters, Indian/Tamil news, science, health, finance
- Total expected: ~160-180 articles in rag_knowledge_base table
- Fixes issue where global website data wasn't flowing into RAG system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Global Knowledge Collection to deliver broader, more consistent responses across the app.
  * Activated complete knowledge seeding to improve initial coverage and reduce cold-start gaps.

* **Chores**
  * Updated service configuration to support the new knowledge capabilities; no existing settings were changed or removed.
  * Backward-compatible change; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->