### PR TITLE
fix: Python version string format for knowledge-seeder

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -72,7 +72,7 @@ services:
     startCommand: "python backend/knowledge_seeding_system.py"
     envVars:
       - key: PYTHON_VERSION
-        value: 3.11.0
+        value: "3.11.0"
       - key: DATABASE_URL
         fromDatabase:
           name: jyotiflow-db


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration for the knowledge seeding worker by quoting the Python version value to ensure consistent parsing by the deployment platform. Aligns configuration formatting and improves reliability during deployments. No user-facing changes; web service configuration remains unchanged. This helps prevent misinterpretation across environments and standardizes our config going forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->