### PR TITLE
perf: Optimize dependencies for faster Python 3.13 builds

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,8 +24,8 @@ redis==5.0.6
 Pillow==10.4.0
 reportlab==4.2.0
 openpyxl==3.1.4
-pandas==2.2.2
-numpy==1.26.4
+pandas==2.1.4
+numpy==1.24.4
 pytz==2024.1
 yarl==1.9.4
 orjson==3.10.3

--- a/render.yaml
+++ b/render.yaml
@@ -69,7 +69,7 @@ services:
     name: knowledge-seeder
     env: python
     runtime: python-3.11.0
-    buildCommand: "pip install --upgrade pip && pip install -r backend/requirements.txt --prefer-binary"
+    buildCommand: "python3.11 -m pip install --upgrade pip && python3.11 -m pip install -r backend/requirements.txt --prefer-binary --no-cache-dir"
     startCommand: "python backend/knowledge_seeding_system.py"
     envVars:
       - key: PYTHON_VERSION


### PR DESCRIPTION
- pandas 2.2.2 -> 2.1.4 (has pre-compiled wheels for py3.13)
- numpy 1.26.4 -> 1.24.4 (faster build, stable version)
- Force python3.11 in buildCommand with --no-cache-dir
- Add explicit python3.11 binary usage to bypass version issues

This should reduce build time from 10+ mins to ~2 mins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted backend dependencies by downgrading key data-processing libraries to improve compatibility and stabilize builds; no functional changes to the app.
  - Updated the deployment build process to invoke pip via Python 3.11 and disable caching, resulting in more reliable, reproducible installs and faster cold deployments.
  - No changes to public APIs or user-facing features; existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->