### PR TITLE
fix: Add asyncpg to main backend requirements and enforce Python 3.12

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,8 @@
 fastapi==0.111.0
 uvicorn[standard]==0.24.0
-# asyncpg==0.29.0  # Python 3.13 compatibility issues, using psycopg2-binary instead
-psycopg2-binary==2.9.9
+asyncpg==0.29.0  # Works fine with Python 3.12
+pgvector==0.2.5  # PostgreSQL vector extension support
+# psycopg2-binary==2.9.9  # Replaced with asyncpg for consistency
 PyJWT==2.8.0
 bcrypt==4.1.2
 python-multipart==0.0.9

--- a/render.yaml
+++ b/render.yaml
@@ -4,6 +4,7 @@ services:
     env: python
     region: oregon
     plan: free
+    runtime: python-3.12.0
     # CORE.MD: Removed OpenCV dependencies - using PIL-only image processing for compatibility
     buildCommand: "pip install --upgrade pip && pip install -r backend/requirements.txt --prefer-binary"
     startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:$PORT"


### PR DESCRIPTION
- Uncommented asyncpg==0.29.0 in backend/requirements.txt (main.py imports it)
- Added pgvector==0.2.5 for vector extension support
- Commented out psycopg2-binary (replaced with asyncpg for consistency)
- Added runtime: python-3.12.0 to main backend service in render.yaml
- This fixes ModuleNotFoundError: No module named 'asyncpg' in main.py line 17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend runtime to Python 3.12 on the deployment platform.
  * Migrated database connectivity to an asynchronous driver for improved efficiency and stability.
  * Enabled PostgreSQL vector extension support to unlock advanced data capabilities.
  * Cleaned up dependencies and removed legacy workarounds for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->