### PR TITLE
Fix/update render build command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     env: python
     region: oregon
     plan: free
-    runtime: python-3.12.0
+    runtime: python
     # CORE.MD: Removed OpenCV dependencies - using PIL-only image processing for compatibility
     buildCommand: "pip install --upgrade pip && pip install -r backend/requirements.txt --prefer-binary"
     startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:$PORT"
@@ -69,7 +69,7 @@ services:
   - type: worker
     name: knowledge-seeder
     env: python
-    runtime: python-3.12.0
+    runtime: python
     buildCommand: "pip install --upgrade pip && pip install -r backend/requirements_minimal.txt --prefer-binary --no-cache-dir"
     startCommand: "python backend/knowledge_seeding_system.py"
     envVars:

--- a/render.yaml
+++ b/render.yaml
@@ -7,13 +7,15 @@ services:
     runtime: python
     # CORE.MD: Removed OpenCV dependencies - using PIL-only image processing for compatibility
     buildCommand: "pip install --upgrade pip && pip install -r backend/requirements.txt --prefer-binary"
-    startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:$PORT"
+    startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT:-10000}"
     healthCheckPath: "/health"
     envVars:
       - key: PYTHON_VERSION
         value: "3.12.0"
       - key: WEB_CONCURRENCY
         value: "1"
+      - key: PORT
+        value: "10000"
 
       # Database Configuration (will use your existing DATABASE_URL from dashboard)
       - key: DATABASE_URL

--- a/render.yaml
+++ b/render.yaml
@@ -7,15 +7,13 @@ services:
     runtime: python
     # CORE.MD: Removed OpenCV dependencies - using PIL-only image processing for compatibility
     buildCommand: "pip install --upgrade pip && pip install -r backend/requirements.txt --prefer-binary"
-    startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT:-10000}"
+    startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT}"
     healthCheckPath: "/health"
     envVars:
       - key: PYTHON_VERSION
         value: "3.12.0"
       - key: WEB_CONCURRENCY
         value: "1"
-      - key: PORT
-        value: "10000"
 
       # Database Configuration (will use your existing DATABASE_URL from dashboard)
       - key: DATABASE_URL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized Python runtime for both web and worker services to a generalized Python runtime.
  - Adjusted web service startup to bind using the PORT variable exactly as provided (removed prior default-port behavior).
  - No PORT environment variable was added; health checks, build commands, and other environment settings remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->