### PR TITLE
fix: Force Python 3.12 explicitly in Render build/start commands

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,10 +6,12 @@ services:
     plan: free
     runtime: python
     # CORE.MD: Removed OpenCV dependencies - using PIL-only image processing for compatibility
-    buildCommand: "python3.12 -m pip install --upgrade pip && python3.12 -m pip install -r backend/requirements.txt --prefer-binary"
-    startCommand: "python3.12 -m gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT}"
+    buildCommand: "python -m pip install --upgrade pip && python -m pip install -r backend/requirements.txt --prefer-binary"
+    startCommand: "python -m gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT}"
     healthCheckPath: "/health"
     envVars:
+      - key: PYTHON_VERSION
+        value: "3.12.10"
       - key: WEB_CONCURRENCY
         value: "1"
 
@@ -68,9 +70,11 @@ services:
     name: knowledge-seeder
     env: python
     runtime: python
-    buildCommand: "python3.12 -m pip install --upgrade pip && python3.12 -m pip install -r backend/requirements_minimal.txt --prefer-binary --no-cache-dir"
-    startCommand: "python3.12 -m backend.knowledge_seeding_system"
+    buildCommand: "python -m pip install --upgrade pip && python -m pip install -r backend/requirements_minimal.txt --prefer-binary --no-cache-dir"
+    startCommand: "python -m backend.knowledge_seeding_system"
     envVars:
+      - key: PYTHON_VERSION
+        value: "3.12.10"
       - key: DATABASE_URL
         fromDatabase:
           name: jyotiflow-db

--- a/render.yaml
+++ b/render.yaml
@@ -6,8 +6,8 @@ services:
     plan: free
     runtime: python
     # CORE.MD: Removed OpenCV dependencies - using PIL-only image processing for compatibility
-    buildCommand: "pip install --upgrade pip && pip install -r backend/requirements.txt --prefer-binary"
-    startCommand: "gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT}"
+    buildCommand: "python3.12 -m pip install --upgrade pip && python3.12 -m pip install -r backend/requirements.txt --prefer-binary"
+    startCommand: "python3.12 -m gunicorn -w ${WEB_CONCURRENCY:-1} -k uvicorn.workers.UvicornWorker backend.main:app --bind 0.0.0.0:${PORT}"
     healthCheckPath: "/health"
     envVars:
       - key: WEB_CONCURRENCY
@@ -68,8 +68,8 @@ services:
     name: knowledge-seeder
     env: python
     runtime: python
-    buildCommand: "pip install --upgrade pip && pip install -r backend/requirements_minimal.txt --prefer-binary --no-cache-dir"
-    startCommand: "python -m backend.knowledge_seeding_system"
+    buildCommand: "python3.12 -m pip install --upgrade pip && python3.12 -m pip install -r backend/requirements_minimal.txt --prefer-binary --no-cache-dir"
+    startCommand: "python3.12 -m backend.knowledge_seeding_system"
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
- Updated buildCommand for both services to use 'python3.12 -m pip install'
- Updated startCommand for jyotiflow-backend to use 'python3.12 -m gunicorn'
- Updated startCommand for knowledge-seeder to use 'python3.12 -m backend.knowledge_seeding_system'
- Ensures Render uses Python 3.12 consistently for builds and runtime
- This should finally resolve the Python 3.11/3.12 conflict and import errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized service build/start to use Python module invocations and aligned runtimes to Python 3.12.

* **Chores**
  * Upgraded pip during builds, prioritized binary wheels, and applied no-cache installs for background tasks.

* **Performance**
  * Potentially faster, more consistent dependency installation during deployments.

* **Reliability**
  * More predictable runtime behavior and improved stability for both web and background services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->