### PR TITLE
fix: Convert absolute imports to relative imports in backend/main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -95,19 +95,19 @@ if sentry_dsn:
 else:
     print("⚠️ Sentry DSN not configured - skipping Sentry initialization")
 
-# Import routers
-from routers import auth, user, spiritual, sessions, followup, donations, credits, services
-from routers import admin_products, admin_subscriptions, admin_credits, admin_analytics, admin_content, admin_settings
-from routers import admin_overview, admin_integrations
-from routers import content, ai, community, session_analytics
-from routers.social_media_marketing_router import social_marketing_router
-import db
+# Import routers - using relative imports to match router files
+from .routers import auth, user, spiritual, sessions, followup, donations, credits, services
+from .routers import admin_products, admin_subscriptions, admin_credits, admin_analytics, admin_content, admin_settings
+from .routers import admin_overview, admin_integrations
+from .routers import content, ai, community, session_analytics
+from .routers.social_media_marketing_router import social_marketing_router
+from . import db
 
 # Import the migration runner
-from run_migrations import MigrationRunner
+from .run_migrations import MigrationRunner
 
 # Import unified startup system
-from simple_unified_startup import initialize_unified_jyotiflow, cleanup_unified_system
+from .simple_unified_startup import initialize_unified_jyotiflow, cleanup_unified_system
 
 # Import enhanced spiritual guidance router
 try:
@@ -206,7 +206,7 @@ except ImportError:
     print("⚠️ Integration monitoring router not available")
 
 # Import database initialization
-from init_database import initialize_jyotiflow_database
+from .init_database import initialize_jyotiflow_database
 
 # Enhanced startup integration and fixes are now consolidated in simple_unified_startup.py
 


### PR DESCRIPTION
- Changed 'from routers import' to 'from .routers import'
- Changed 'import db' to 'from . import db'
- Changed 'from run_migrations import' to 'from .run_migrations import'
- Changed 'from simple_unified_startup import' to 'from .simple_unified_startup import'
- Changed 'from init_database import' to 'from .init_database import'
- Ensures consistent relative import style matching router files
- Fixes ImportError: attempted relative import beyond top-level package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal import paths across backend modules to match package structure. This change is strictly organizational and does not modify runtime logic, control flow, or error handling. No public APIs or interfaces were altered. End users should not observe any behavioral differences, and existing functionality remains unchanged. Installation and deployment behaviors are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->